### PR TITLE
PROXY protocol support

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -10,6 +10,7 @@
     "recovery-server": "172.30.0.101:2222",
     "recovery-username": ["recovery", "console", "serial"],
     "all-username-nopassword": true,
+    "enable-proxy-protocol": false,
     "username-nopassword": ["vlab", "ubuntu", "root"],
     "invalid-username": ["用户名"],
     "invalid-username-message": "Invalid username %s. Please check https://vlab.ustc.edu.cn/docs/login/ssh/#username for more information.",

--- a/config.example.json
+++ b/config.example.json
@@ -10,7 +10,7 @@
     "recovery-server": "172.30.0.101:2222",
     "recovery-username": ["recovery", "console", "serial"],
     "all-username-nopassword": true,
-    "enable-proxy-protocol": false,
+    "enable-proxy-protocol": true,
     "username-nopassword": ["vlab", "ubuntu", "root"],
     "invalid-username": ["用户名"],
     "invalid-username-message": "Invalid username %s. Please check https://vlab.ustc.edu.cn/docs/login/ssh/#username for more information.",

--- a/config.example.json
+++ b/config.example.json
@@ -1,6 +1,8 @@
 {
     "address": "0.0.0.0:8022",
-    "proxied-address": "0.0.0.0:8122",
+    "proxy-protocol-allowed-cidrs": [
+        "127.0.0.22/32"
+    ],
     "host-keys": [
         "/tmp/sshmux/ssh_host_ed25519_key",
         "/tmp/sshmux/ssh_host_ecdsa_key",

--- a/config.example.json
+++ b/config.example.json
@@ -1,6 +1,5 @@
 {
     "address": "0.0.0.0:8022",
-    "proxied-address": "0.0.0.0:8122",
     "host-keys": [
         "/tmp/sshmux/ssh_host_ed25519_key",
         "/tmp/sshmux/ssh_host_ecdsa_key",

--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,6 @@
 {
     "address": "0.0.0.0:8022",
+    "proxied-address": "0.0.0.0:8122",
     "host-keys": [
         "/tmp/sshmux/ssh_host_ed25519_key",
         "/tmp/sshmux/ssh_host_ecdsa_key",
@@ -10,7 +11,6 @@
     "recovery-server": "172.30.0.101:2222",
     "recovery-username": ["recovery", "console", "serial"],
     "all-username-nopassword": true,
-    "enable-proxy-protocol": true,
     "username-nopassword": ["vlab", "ubuntu", "root"],
     "invalid-username": ["用户名"],
     "invalid-username-message": "Invalid username %s. Please check https://vlab.ustc.edu.cn/docs/login/ssh/#username for more information.",

--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,6 @@
 {
     "address": "0.0.0.0:8022",
+    "proxied-address": "0.0.0.0:8122",
     "host-keys": [
         "/tmp/sshmux/ssh_host_ed25519_key",
         "/tmp/sshmux/ssh_host_ecdsa_key",

--- a/crypto/ssh/pipe.go
+++ b/crypto/ssh/pipe.go
@@ -24,9 +24,8 @@ type Upstream struct {
 }
 
 type PipeSession struct {
-	Downstream    *Downstream
-	Upstream      *Upstream
-	ProxyProtocol bool
+	Downstream *Downstream
+	Upstream   *Upstream
 }
 
 type AuthRequest struct {
@@ -43,7 +42,7 @@ type AuthResult struct {
 	PartialSuccess bool
 }
 
-func NewPipeSession(c net.Conn, config *ServerConfig, proxyProtocol bool) (session *PipeSession, err error) {
+func NewPipeSession(c net.Conn, config *ServerConfig) (session *PipeSession, err error) {
 	serverConfig := *config
 	serverConfig.SetDefaults()
 	conn := &connection{
@@ -63,8 +62,7 @@ func NewPipeSession(c net.Conn, config *ServerConfig, proxyProtocol bool) (sessi
 	}()
 
 	session = &PipeSession{
-		Downstream:    downstream,
-		ProxyProtocol: proxyProtocol,
+		Downstream: downstream,
 	}
 
 	return session, nil

--- a/crypto/ssh/pipe.go
+++ b/crypto/ssh/pipe.go
@@ -24,8 +24,9 @@ type Upstream struct {
 }
 
 type PipeSession struct {
-	Downstream *Downstream
-	Upstream   *Upstream
+	Downstream    *Downstream
+	Upstream      *Upstream
+	ProxyProtocol bool
 }
 
 type AuthRequest struct {
@@ -42,7 +43,7 @@ type AuthResult struct {
 	PartialSuccess bool
 }
 
-func NewPipeSession(c net.Conn, config *ServerConfig) (session *PipeSession, err error) {
+func NewPipeSession(c net.Conn, config *ServerConfig, proxyProtocol bool) (session *PipeSession, err error) {
 	serverConfig := *config
 	serverConfig.SetDefaults()
 	conn := &connection{
@@ -62,7 +63,8 @@ func NewPipeSession(c net.Conn, config *ServerConfig) (session *PipeSession, err
 	}()
 
 	session = &PipeSession{
-		Downstream: downstream,
+		Downstream:    downstream,
+		ProxyProtocol: proxyProtocol,
 	}
 
 	return session, nil

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,9 @@ go 1.21
 
 require golang.org/x/crypto v0.24.0
 
-require golang.org/x/sys v0.21.0 // indirect
+require (
+	github.com/pires/go-proxyproto v0.7.0 // indirect
+	golang.org/x/sys v0.21.0 // indirect
+)
 
 replace golang.org/x/crypto => ./crypto

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,8 @@ module github.com/USTC-vlab/sshmux
 go 1.21
 
 require golang.org/x/crypto v0.24.0
+require github.com/pires/go-proxyproto v0.7.0
 
-require (
-	github.com/pires/go-proxyproto v0.7.0 // indirect
-	golang.org/x/sys v0.21.0 // indirect
-)
+require golang.org/x/sys v0.21.0 // indirect
 
 replace golang.org/x/crypto => ./crypto

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/pires/go-proxyproto v0.7.0 h1:IukmRewDQFWC7kfnb66CSomk2q/seBuilHBYFwyq0Hs=
+github.com/pires/go-proxyproto v0.7.0/go.mod h1:Vz/1JPY/OACxWGQNIRY2BeyDmpoaWmEP40O9LbuiFR4=
 golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
 golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.21.0 h1:WVXCp+/EBEHOj53Rvu+7KiT/iElMrO8ACK16SMZ3jaA=

--- a/sshmux.go
+++ b/sshmux.go
@@ -66,7 +66,7 @@ type AuthResponse struct {
 	PrivateKey string `json:"private_key"`
 	Cert       string `json:"cert"`
 	Id         int    `json:"vmid"`
-	Proxy      bool   `json:"proxy_protocol,omitempty"`
+	Proxy      *bool  `json:"proxy_protocol,omitempty"`
 }
 
 type UpstreamInformation struct {
@@ -130,7 +130,11 @@ func authUser(request any, username string) (*UpstreamInformation, error) {
 		upstream.Host = response.Address
 	}
 	upstream.Signer = parsePrivateKey(response.PrivateKey, response.Cert)
-	upstream.Proxy = response.Proxy
+	if response.Proxy != nil && *response.Proxy {
+		upstream.Proxy = true
+	} else {
+		upstream.Proxy = false
+	}
 	return &upstream, nil
 }
 

--- a/sshmux.go
+++ b/sshmux.go
@@ -252,7 +252,7 @@ func handshake(session *ssh.PipeSession) error {
 		return err
 	}
 	if config.EnableProxyProtocol {
-		header := proxyproto.HeaderProxyFromAddrs(1, session.Downstream.RemoteAddr(), conn.RemoteAddr())
+		header := proxyproto.HeaderProxyFromAddrs(1, session.Downstream.RemoteAddr(), nil)
 		_, err := header.WriteTo(conn)
 		if err != nil {
 			return err

--- a/sshmux.go
+++ b/sshmux.go
@@ -14,7 +14,7 @@ import (
 	"slices"
 	"time"
 
-	proxyproto "github.com/pires/go-proxyproto"
+	"github.com/pires/go-proxyproto"
 	"golang.org/x/crypto/ssh"
 )
 

--- a/sshmux.go
+++ b/sshmux.go
@@ -66,7 +66,7 @@ type AuthResponse struct {
 	PrivateKey    string `json:"private_key"`
 	Cert          string `json:"cert"`
 	Id            int    `json:"vmid"`
-	ProxyProtocol *byte  `json:"proxy_protocol,omitempty"`
+	ProxyProtocol byte   `json:"proxy_protocol,omitempty"`
 }
 
 type UpstreamInformation struct {
@@ -130,9 +130,7 @@ func authUser(request any, username string) (*UpstreamInformation, error) {
 		upstream.Host = response.Address
 	}
 	upstream.Signer = parsePrivateKey(response.PrivateKey, response.Cert)
-	if response.ProxyProtocol != nil {
-		upstream.ProxyProtocol = *response.ProxyProtocol
-	}
+	upstream.ProxyProtocol = response.ProxyProtocol
 	return &upstream, nil
 }
 

--- a/sshmux_test.go
+++ b/sshmux_test.go
@@ -74,7 +74,7 @@ func initUpstreamProxyServer() {
 
 		go func() {
 			// 1. Set up downstream connection with sshmux
-			target, err := net.ResolveTCPAddr("tcp", "127.0.0.1:8022")
+			target, err := net.ResolveTCPAddr("tcp", "127.0.0.1:8122")
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -226,11 +226,21 @@ func TestSSHClientConnection(t *testing.T) {
 	}
 	waitForSSHD(t, cmd)
 
+	// test sshmux
+	cmd = onetimeSSHDServer(t, baseDir)
+	time.Sleep(sleepDuration)
+	err = sshCommand("8022", privateKeyPath).Run()
+	if err != nil {
+		t.Fatal("ssh: ", err)
+	}
+	waitForSSHD(t, cmd)
+
+	// test sshmux with proxy protocol
 	cmd = onetimeSSHDServer(t, baseDir)
 	time.Sleep(sleepDuration)
 	err = sshCommand("9999", privateKeyPath).Run()
 	if err != nil {
-		t.Fatal("ssh: ", err)
+		t.Fatal("ssh (proxied): ", err)
 	}
 	waitForSSHD(t, cmd)
 }

--- a/sshmux_test.go
+++ b/sshmux_test.go
@@ -65,7 +65,6 @@ func initUpstreamProxyServer() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer listener.Close()
 
 	go func() {
 		for {
@@ -119,10 +118,7 @@ func initDownstreamProxyServer() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer listener.Close()
-
 	proxyListener := &proxyproto.Listener{Listener: listener}
-	defer proxyListener.Close()
 
 	go func() {
 		for {

--- a/sshmux_test.go
+++ b/sshmux_test.go
@@ -57,9 +57,8 @@ func sshAPIHandler(w http.ResponseWriter, r *http.Request) {
 		PrivateKey: examplePrivate,
 	}
 	if enableProxy {
-		version := byte(2)
 		res.Address = sshdProxyAddr.String()
-		res.ProxyProtocol = &version
+		res.ProxyProtocol = 2
 	} else {
 		res.Address = sshdServerAddr.String()
 	}

--- a/sshmux_test.go
+++ b/sshmux_test.go
@@ -16,7 +16,8 @@ import (
 	"github.com/pires/go-proxyproto"
 )
 
-var sshmuxProxyAddr *net.TCPAddr = localhostTCPAddr(8122)
+var sshmuxProxyAddr *net.TCPAddr = localhostTCPAddr(8222)
+var sshmuxProxiedAddr *net.TCPAddr = localhostTCPAddr(8122)
 var sshmuxServerAddr *net.TCPAddr = localhostTCPAddr(8022)
 var sshdProxyAddr *net.TCPAddr = localhostTCPAddr(2332)
 var sshdServerAddr *net.TCPAddr = localhostTCPAddr(2333)
@@ -95,7 +96,7 @@ func initUpstreamProxyServer() {
 
 		go func() {
 			// 1. Set up downstream connection with sshmux
-			sshmux, err := net.DialTCP("tcp", nil, sshmuxServerAddr)
+			sshmux, err := net.DialTCP("tcp", nil, sshmuxProxiedAddr)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/sshmux_test.go
+++ b/sshmux_test.go
@@ -112,7 +112,7 @@ func initUpstreamProxyServer() {
 				io.Copy(sshmux, conn)
 			}()
 			go func() {
-				defer sshmux.Close()
+				defer conn.Close()
 				io.Copy(conn, sshmux)
 			}()
 		}()
@@ -151,7 +151,7 @@ func initDownstreamProxyServer() {
 				io.Copy(sshd, conn)
 			}()
 			go func() {
-				defer sshd.Close()
+				defer conn.Close()
 				io.Copy(conn, sshd)
 			}()
 		}()

--- a/sshmux_test.go
+++ b/sshmux_test.go
@@ -57,12 +57,11 @@ func sshAPIHandler(w http.ResponseWriter, r *http.Request) {
 		PrivateKey: examplePrivate,
 	}
 	if enableProxy {
+		version := byte(2)
 		res.Address = sshdProxyAddr.String()
-		res.Proxy = new(bool)
-		*res.Proxy = true
+		res.ProxyProtocol = &version
 	} else {
 		res.Address = sshdServerAddr.String()
-		res.Proxy = nil
 	}
 
 	jsonRes, err := json.Marshal(res)
@@ -102,7 +101,7 @@ func initUpstreamProxyServer() {
 				log.Fatal(err)
 			}
 			// 2. Send PROXY header to sshmux
-			header := proxyproto.HeaderProxyFromAddrs(1, conn.RemoteAddr(), nil)
+			header := proxyproto.HeaderProxyFromAddrs(2, conn.RemoteAddr(), nil)
 			_, err = header.WriteTo(sshmux)
 			if err != nil {
 				log.Fatal(err)

--- a/sshmux_test.go
+++ b/sshmux_test.go
@@ -19,7 +19,7 @@ import (
 var sshmuxProxyAddr *net.TCPAddr = localhostTCPAddr(8222)
 var sshmuxProxiedAddr *net.TCPAddr = localhostTCPAddr(8122)
 var sshmuxServerAddr *net.TCPAddr = localhostTCPAddr(8022)
-var sshdProxyAddr *net.TCPAddr = localhostTCPAddr(2332)
+var sshdProxiedAddr *net.TCPAddr = localhostTCPAddr(2332)
 var sshdServerAddr *net.TCPAddr = localhostTCPAddr(2333)
 var apiServerAddr *net.TCPAddr = localhostTCPAddr(5000)
 
@@ -58,7 +58,7 @@ func sshAPIHandler(w http.ResponseWriter, r *http.Request) {
 		PrivateKey: examplePrivate,
 	}
 	if enableProxy {
-		res.Address = sshdProxyAddr.String()
+		res.Address = sshdProxiedAddr.String()
 		res.ProxyProtocol = 2
 	} else {
 		res.Address = sshdServerAddr.String()
@@ -106,7 +106,7 @@ func initUpstreamProxyServer() {
 			if err != nil {
 				log.Fatal(err)
 			}
-			// 3. Forward TCP messages in both ways
+			// 3. Forward TCP messages in both directions
 			go func() {
 				defer sshmux.Close()
 				io.Copy(sshmux, conn)
@@ -120,7 +120,7 @@ func initUpstreamProxyServer() {
 }
 
 func initDownstreamProxyServer() {
-	listener, err := net.ListenTCP("tcp", sshdProxyAddr)
+	listener, err := net.ListenTCP("tcp", sshdProxiedAddr)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -145,7 +145,7 @@ func initDownstreamProxyServer() {
 			if err != nil {
 				log.Fatal(err)
 			}
-			// 2. Forward TCP messages in both ways
+			// 2. Forward TCP messages in both directions
 			go func() {
 				defer sshd.Close()
 				io.Copy(sshd, conn)

--- a/sshmux_test.go
+++ b/sshmux_test.go
@@ -16,8 +16,7 @@ import (
 	"github.com/pires/go-proxyproto"
 )
 
-var sshmuxProxyAddr *net.TCPAddr = localhostTCPAddr(8222)
-var sshmuxProxiedAddr *net.TCPAddr = localhostTCPAddr(8122)
+var sshmuxProxyAddr *net.TCPAddr = localhostTCPAddr(8122)
 var sshmuxServerAddr *net.TCPAddr = localhostTCPAddr(8022)
 var sshdProxiedAddr *net.TCPAddr = localhostTCPAddr(2332)
 var sshdServerAddr *net.TCPAddr = localhostTCPAddr(2333)
@@ -88,6 +87,8 @@ func initUpstreamProxyServer() {
 	}
 	defer listener.Close()
 
+	localAddr := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 22)}
+
 	for {
 		conn, err := listener.Accept()
 		if err != nil {
@@ -96,7 +97,7 @@ func initUpstreamProxyServer() {
 
 		go func() {
 			// 1. Set up downstream connection with sshmux
-			sshmux, err := net.DialTCP("tcp", nil, sshmuxProxiedAddr)
+			sshmux, err := net.DialTCP("tcp", localAddr, sshmuxServerAddr)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/sshmux_test.go
+++ b/sshmux_test.go
@@ -4,12 +4,16 @@ import (
 	"encoding/json"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
+
+	"github.com/pires/go-proxyproto"
 )
 
 func mustGenerateKey(t *testing.T, path, typ string) {
@@ -35,7 +39,7 @@ func sshAPIHandler(w http.ResponseWriter, r *http.Request) {
 
 	res := &AuthResponse{
 		Status:     "ok",
-		Address:    "127.0.0.1:2333",
+		Address:    "127.0.0.1:2332",
 		Id:         1141919,
 		PrivateKey: examplePrivate,
 	}
@@ -54,6 +58,111 @@ func initHttp() {
 	if err := http.ListenAndServe("127.0.0.1:5000", nil); err != nil {
 		log.Fatal(err)
 	}
+}
+
+func initUpstreamProxyServer() {
+	listener, err := net.Listen("tcp", "127.0.0.1:2222")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer listener.Close()
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				log.Print(err)
+				continue
+			}
+
+			go func() {
+				// 1. Set up downstream connection with sshmux
+				target, err := net.ResolveTCPAddr("tcp", "127.0.0.1:8022")
+				if err != nil {
+					log.Fatal(err)
+				}
+				downstream, err := net.DialTCP("tcp", nil, target)
+				if err != nil {
+					log.Fatal(err)
+				}
+				// 2. Send PROXY header
+				header := proxyproto.HeaderProxyFromAddrs(1, conn.RemoteAddr(), downstream.RemoteAddr())
+				_, err = header.WriteTo(downstream)
+				if err != nil {
+					log.Fatal(err)
+				}
+				// 3. Forward TCP messages in a loop
+				for {
+					data := make([]byte, 0)
+					_, err := conn.Read(data)
+					if err != nil {
+						if err == syscall.EINVAL {
+							downstream.Close()
+						} else {
+							log.Print(err)
+						}
+						break
+					}
+					_, err = downstream.Write(data)
+					if err != nil {
+						log.Print(err)
+						break
+					}
+				}
+			}()
+		}
+	}()
+}
+
+func initDownstreamProxyServer() {
+	listener, err := net.Listen("tcp", "127.0.0.1:2232")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer listener.Close()
+
+	proxyListener := &proxyproto.Listener{Listener: listener}
+	defer proxyListener.Close()
+
+	go func() {
+		for {
+			conn, err := proxyListener.Accept()
+			if err != nil {
+				log.Print(err)
+				continue
+			}
+
+			go func() {
+				// 1. Set up downstream connection with sshmux
+				target, err := net.ResolveTCPAddr("tcp", "127.0.0.1:2333")
+				if err != nil {
+					log.Fatal(err)
+				}
+				downstream, err := net.DialTCP("tcp", nil, target)
+				if err != nil {
+					log.Fatal(err)
+				}
+				// 2. Forward TCP messages in a loop
+				for {
+					data := make([]byte, 0)
+					_, err := conn.Read(data)
+					if err != nil {
+						if err == syscall.EINVAL {
+							downstream.Close()
+						} else {
+							log.Print(err)
+						}
+						break
+					}
+					_, err = downstream.Write(data)
+					if err != nil {
+						log.Print(err)
+						break
+					}
+				}
+			}()
+		}
+	}()
 }
 
 func initEnv(t *testing.T, baseDir string) {
@@ -83,6 +192,8 @@ func initEnv(t *testing.T, baseDir string) {
 
 	// Setup API Server
 	go initHttp()
+	go initUpstreamProxyServer()
+	go initDownstreamProxyServer()
 }
 
 func onetimeSSHDServer(t *testing.T, baseDir string) *exec.Cmd {
@@ -144,7 +255,7 @@ func TestSSHClientConnection(t *testing.T) {
 
 	cmd = onetimeSSHDServer(t, baseDir)
 	time.Sleep(sleepDuration)
-	err = sshCommand("8022", privateKeyPath).Run()
+	err = sshCommand("2222", privateKeyPath).Run()
 	if err != nil {
 		t.Fatal("ssh: ", err)
 	}

--- a/sshmux_test.go
+++ b/sshmux_test.go
@@ -84,7 +84,7 @@ func initUpstreamProxyServer() {
 				log.Fatal(err)
 			}
 			// 2. Send PROXY header
-			header := proxyproto.HeaderProxyFromAddrs(1, conn.RemoteAddr(), downstream.RemoteAddr())
+			header := proxyproto.HeaderProxyFromAddrs(1, conn.RemoteAddr(), nil)
 			_, err = header.WriteTo(downstream)
 			if err != nil {
 				log.Fatal(err)

--- a/sshmux_test.go
+++ b/sshmux_test.go
@@ -82,13 +82,13 @@ func initUpstreamProxyServer() {
 			if err != nil {
 				log.Fatal(err)
 			}
-			// 2. Send PROXY header
+			// 2. Send PROXY header to downstream
 			header := proxyproto.HeaderProxyFromAddrs(1, conn.RemoteAddr(), nil)
 			_, err = header.WriteTo(downstream)
 			if err != nil {
 				log.Fatal(err)
 			}
-			// 3. Forward TCP messages in a loop
+			// 3. Forward TCP messages in both ways
 			go func() {
 				defer downstream.Close()
 				io.Copy(downstream, conn)
@@ -125,7 +125,7 @@ func initDownstreamProxyServer() {
 			if err != nil {
 				log.Fatal(err)
 			}
-			// 2. Forward TCP messages in a loop
+			// 2. Forward TCP messages in both ways
 			go func() {
 				defer downstream.Close()
 				io.Copy(downstream, conn)

--- a/sshmux_test.go
+++ b/sshmux_test.go
@@ -58,10 +58,11 @@ func sshAPIHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	if enableProxy {
 		res.Address = sshdProxyAddr.String()
-		res.Proxy = true
+		res.Proxy = new(bool)
+		*res.Proxy = true
 	} else {
 		res.Address = sshdServerAddr.String()
-		res.Proxy = false
+		res.Proxy = nil
 	}
 
 	jsonRes, err := json.Marshal(res)

--- a/sshmux_test.go
+++ b/sshmux_test.go
@@ -114,7 +114,7 @@ func initUpstreamProxyServer() {
 }
 
 func initDownstreamProxyServer() {
-	listener, err := net.Listen("tcp", "127.0.0.1:2232")
+	listener, err := net.Listen("tcp", "127.0.0.1:2332")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
[PROXY protocol](https://www.haproxy.com/blog/use-the-proxy-protocol-to-preserve-a-clients-ip-address), originally developed by [HAProxy](https://www.haproxy.com/), extends the TCP protocol to explicitly preserve source (and destination) IPs when it's proxied.

This PR adds bidirectional PROXY protocol support to `sshmux`, opt-in by the API server and configuration file.