### PR TITLE
Refactor with minor improvements, and add README

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         CGO_ENABLED: 0
     - name: Create GitHub Release
       if: startsWith(github.ref, 'refs/tags/')
-      id: upload-release-asset 
+      id: upload-release-asset
       uses: softprops/action-gh-release@v1
       with:
         files: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,8 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/ustc-vlab/sshmux
+          images: |
+            ghcr.io/${{ github.repository_owner }}/sshmux
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The table below shows the available options for `sshmux`:
 |-------------|------------|--------------------------------------------------------------------|----------|------------------------------------|
 | `address`   | `string`   | TCP host and port that `sshmux` will listen on.                    | `true`   | `"0.0.0.0:8022"`                   |
 | `api`       | `string`   | HTTP address that `sshmux` shall interact with.                    | `true`   | `"http://127.0.0.1:5000/ssh"`      |
+| `token`     | `string`   | Token used to authenticate with the API endpoint.                  | `true`   | `"long-and-random-token"`          |
 | `banner`    | `string`   | SSH banner to send to downstream.                                  | `false`  | `"Welcome to Vlab\n"`              |
 | `logger`    | `string`   | UDP host and port that `sshmux` send log messages to.              | `false`  | `"127.0.0.1:5556"`                 |
 | `host-keys` | `[]string` | Paths to SSH host key files with which `sshmux` identifies itself. | `true`   | `["/sshmux/ssh_host_ed25519_key"]` |
@@ -29,15 +30,15 @@ The table below shows the available options for `sshmux`:
 
 The table below shows extra options for `sshmux`, mainly for authentication with Vlab backends:
 
-| Key                        | Type       | Description                                                 | Example                      |
-|----------------------------|------------|-------------------------------------------------------------|------------------------------|
-| `token`                    | `string`   | Token used to authenticate with the recovery backend.       | `"long-and-random-token"`    |
-| `recovery-server`          | `string`   | SSH host and port of the recovery server.                   | `"172.30.0.101:2222"`        |
-| `recovery-username`        | `[]string` | Usernames dedicated to the recovery server.                 | `["recovery", "console"]`    |
-| `all-username-nopassword`  | `bool`     | If set to `true`, no users will be asked for UNIX password. | `true`                       |
-| `username-nopassword`      | `[]string` | Usernames that won't be asked for UNIX password.            | `["vlab", "ubuntu", "root"]` |
-| `invalid-username`         | `[]string` | Usernames that are known to be invalid.                     | `["user"]`                   |
-| `invalid-username-message` | `string`   | Message to display when the requested username is invalid.  | `"Invalid username %s."`     |
+| Key                        | Type       | Description                                                                | Example                      |
+|----------------------------|------------|----------------------------------------------------------------------------|------------------------------|
+| `recovery-token`           | `string`   | Token used to authenticate with the recovery backend. Defaults to `token`. | `"long-and-random-token"`    |
+| `recovery-server`          | `string`   | SSH host and port of the recovery server.                                  | `"172.30.0.101:2222"`        |
+| `recovery-username`        | `[]string` | Usernames dedicated to the recovery server.                                | `["recovery", "console"]`    |
+| `all-username-nopassword`  | `bool`     | If set to `true`, no users will be asked for UNIX password.                | `true`                       |
+| `username-nopassword`      | `[]string` | Usernames that won't be asked for UNIX password.                           | `["vlab", "ubuntu", "root"]` |
+| `invalid-username`         | `[]string` | Usernames that are known to be invalid.                                    | `["user"]`                   |
+| `invalid-username-message` | `string`   | Message to display when the requested username is invalid.                 | `"Invalid username %s."`     |
 
 All of these options can be left empty or unset, if the corresponding feature is not intended to be used.
 
@@ -55,7 +56,7 @@ The API accepts JSON input with the following keys:
 | `unix_username`   | `string` | UNIX username the user is requesting access to.                                                        |
 | `public_key_type` | `string` | SSH public key type. Unset if the user is authenticating with username and password.                   |
 | `public_key_data` | `string` | Base64-encoded SSH public key payload. Unset if the user is authenticating with username and password. |
-| `token`           | `string` | Token used to authenticate with the recovery backend.                                                  |
+| `token`           | `string` | Token used to authenticate the `sshmux` instance.                                                      |
 
 The API responds with JSON output with the following keys:
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 
 `sshmux` requires a Go 1.21+ toolchain to build. You can use `go build` or `make` to get the `sshmux` binary directly in the directory.
 
-You can run the binary with `./sshmux`. Note that you'll need to provide a valid configuration file as described [here](#config).
+You can run the built binary with `./sshmux`. Note that you'll need to provide a valid configuration file as described [here](#config).
 
-You can perform the unit tests with `go test` or `make test`. Enable verbose logging with `go test -v`.
+You can perform unit tests with `go test` or `make test`. Enable verbose logging with `go test -v`.
 
 ## Config
 
-`sshmux` requires a JSON configuration file to start up. By default it will look at `/etc/sshmux/config.json`, but you can also specify a custom configuration by passing `-c path/to/config.json` in the command line arguments. An example [`config.example.json`](config.example.json) file is provided.
+`sshmux` requires a JSON configuration file to start up. By default it will look at `/etc/sshmux/config.json`, but you can also specify a custom configuration by passing `-c path/to/config.json` in the command line arguments. An [example](config.example.json) file is provided.
 
 The table below shows the available options for `sshmux`:
 
@@ -24,7 +24,7 @@ The table below shows the available options for `sshmux`:
 | `token`     | `string`   | Token used to authenticate with the API endpoint.                  | `true`   | `"long-and-random-token"`          |
 | `banner`    | `string`   | SSH banner to send to downstream.                                  | `false`  | `"Welcome to Vlab\n"`              |
 | `logger`    | `string`   | UDP host and port that `sshmux` send log messages to.              | `false`  | `"127.0.0.1:5556"`                 |
-| `proxy-protocol-allowed-cidrs` | `[]string` | CIDRs for which [PROXY protocol](https://www.haproxy.com/blog/use-the-proxy-protocol-to-preserve-a-clients-ip-address) is allowed. | `false` | `["127.0.0.22/32"]` |
+| `proxy-protocol-allowed-cidrs` | `[]string` | CIDRs from which [PROXY protocol](https://www.haproxy.com/blog/use-the-proxy-protocol-to-preserve-a-clients-ip-address) is allowed. | `false` | `["127.0.0.22/32"]` |
 
 ### Advanced Config
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# sshmux
+
+`sshmux` is a new, simple implementation of SSH reverse proxy. `sshmux` was initially developed for Vlab, while we'd like to expand its usage to cover more scenarios.
+
+## Build, Run and Test
+
+`sshmux` requires a Go 1.21+ toolchain to build. You can use `go build -ldflags='-s -w'` or `make all` to get the `sshmux` binary directly in the directory.
+
+You can run the binary with `./sshmux`. Note that you'll need to provide a valid configuration file as described [here](#config).
+
+You can perform the unit test with `go test` or `make test`. Enable verbose logging with `go test -v`.
+
+## Config
+
+`sshmux` requires a JSON configuration file to start up. By default it will look at `/etc/sshmux/config.json`, but you can also specify a custom configuration by passing `-c path/to/config.json` in the command line arguments. An example [`config.example.json`](config.example.json) file is provided.
+
+The table below shows the available options for `sshmux`:
+
+| Key         | Type       | Description                                                        | Required | Example                            |
+|-------------|------------|--------------------------------------------------------------------|----------|------------------------------------|
+| `address`   | `string`   | TCP host and port that `sshmux` will listen on.                    | `true`   | `"0.0.0.0:8022"`                   |
+| `api`       | `string`   | HTTP address that `sshmux` shall interact with.                    | `true`   | `"http://127.0.0.1:5000/ssh"`      |
+| `banner`    | `string`   | SSH banner to send to downstream.                                  | `false`  | `"Welcome to Vlab\n"`              |
+| `logger`    | `string`   | UDP host and port that `sshmux` send log messages to.              | `false`  | `"127.0.0.1:5556"`                 |
+| `host-keys` | `[]string` | Paths to SSH host key files with which `sshmux` identifies itself. | `true`   | `["/sshmux/ssh_host_ed25519_key"]` |
+| `proxy-protocol-allowed-cidrs` | `[]string` | CIDRs for which [PROXY protocol](https://www.haproxy.com/blog/use-the-proxy-protocol-to-preserve-a-clients-ip-address) is allowed. | `false` | `["127.0.0.22/32"]` |
+
+### Advanced Config
+
+The table below shows extra options for `sshmux`, mainly for authentication with Vlab backends:
+
+| Key                        | Type       | Description                                                      | Example                      |
+|----------------------------|------------|------------------------------------------------------------------|------------------------------|
+| `token`                    | `string`   | Token used to authenticate with the recovery backend.            | `"long-and-random-token"`    |
+| `recovery-server`          | `string`   | SSH host and port of the recovery server.                        | `"172.30.0.101:2222"`        |
+| `recovery-username`        | `[]string` | Usernames dedicated to the recovery server.                      | `["recovery", "console"]`    |
+| `all-username-nopassword`  | `bool`     | If set to `true`, all users will not be asked for UNIX password. | `true`                       |
+| `username-nopassword`      | `[]string` | Usernames that won't be asked for UNIX password.                 | `["vlab", "ubuntu", "root"]` |
+| `invalid-username`         | `[]string` | Usernames that are known to be invalid.                          | `["user"]`                   |
+| `invalid-username-message` | `string`   | Message to display when the requested username is invalid.       | `"Invalid username %s."`     |

--- a/README.md
+++ b/README.md
@@ -29,12 +29,41 @@ The table below shows the available options for `sshmux`:
 
 The table below shows extra options for `sshmux`, mainly for authentication with Vlab backends:
 
-| Key                        | Type       | Description                                                      | Example                      |
-|----------------------------|------------|------------------------------------------------------------------|------------------------------|
-| `token`                    | `string`   | Token used to authenticate with the recovery backend.            | `"long-and-random-token"`    |
-| `recovery-server`          | `string`   | SSH host and port of the recovery server.                        | `"172.30.0.101:2222"`        |
-| `recovery-username`        | `[]string` | Usernames dedicated to the recovery server.                      | `["recovery", "console"]`    |
-| `all-username-nopassword`  | `bool`     | If set to `true`, all users will not be asked for UNIX password. | `true`                       |
-| `username-nopassword`      | `[]string` | Usernames that won't be asked for UNIX password.                 | `["vlab", "ubuntu", "root"]` |
-| `invalid-username`         | `[]string` | Usernames that are known to be invalid.                          | `["user"]`                   |
-| `invalid-username-message` | `string`   | Message to display when the requested username is invalid.       | `"Invalid username %s."`     |
+| Key                        | Type       | Description                                                 | Example                      |
+|----------------------------|------------|-------------------------------------------------------------|------------------------------|
+| `token`                    | `string`   | Token used to authenticate with the recovery backend.       | `"long-and-random-token"`    |
+| `recovery-server`          | `string`   | SSH host and port of the recovery server.                   | `"172.30.0.101:2222"`        |
+| `recovery-username`        | `[]string` | Usernames dedicated to the recovery server.                 | `["recovery", "console"]`    |
+| `all-username-nopassword`  | `bool`     | If set to `true`, no users will be asked for UNIX password. | `true`                       |
+| `username-nopassword`      | `[]string` | Usernames that won't be asked for UNIX password.            | `["vlab", "ubuntu", "root"]` |
+| `invalid-username`         | `[]string` | Usernames that are known to be invalid.                     | `["user"]`                   |
+| `invalid-username-message` | `string`   | Message to display when the requested username is invalid.  | `"Invalid username %s."`     |
+
+All of these options can be left empty or unset, if the corresponding feature is not intended to be used.
+
+## API server
+
+`sshmux` requires an API server to perform authentication and authorization for a user.
+
+The API accepts JSON input with the following keys:
+
+| Key               | Type     | Description                                                                                            |
+|-------------------|----------|--------------------------------------------------------------------------------------------------------|
+| `auth_type`       | `string` | The authentication type. Always set to `"key"` at the moment.                                          |
+| `username`        | `string` | Vlab username. Unset if the user is authenticating with public key.                                    |
+| `password`        | `string` | Vlab password. Unset if the user is authenticating with public key.                                    |
+| `unix_username`   | `string` | UNIX username the user is requesting access to.                                                        |
+| `public_key_type` | `string` | SSH public key type. Unset if the user is authenticating with username and password.                   |
+| `public_key_data` | `string` | Base64-encoded SSH public key payload. Unset if the user is authenticating with username and password. |
+| `token`           | `string` | Token used to authenticate with the recovery backend.                                                  |
+
+The API responds with JSON output with the following keys:
+
+| Key              | Type      | Description                                                                                                          |
+|------------------|-----------|----------------------------------------------------------------------------------------------------------------------|
+| `status`         | `string`  | The authentication status. Should be `"ok"` if the user is authorized.                                               |
+| `address`        | `string`  | TCP host and port of the downstream SSH server the user is requesting for.                                           |
+| `private_key`    | `string`  | SSH private key to authenticate for the downstream.                                                                  |
+| `cert`           | `string`  | The certificate associated with the SSH private key.                                                                 |
+| `vmid`           | `integer` | ID of the requested VM. Only used for recovery access.                                                               |
+| `proxy_protocol` | `integer` | PROXY protocol version to use for the downstream. Should be `1`, `2` or null values (which disables PROXY protocol). |

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 ## Build, Run and Test
 
-`sshmux` requires a Go 1.21+ toolchain to build. You can use `go build -ldflags='-s -w'` or `make all` to get the `sshmux` binary directly in the directory.
+`sshmux` requires a Go 1.21+ toolchain to build. You can use `go build` or `make all` to get the `sshmux` binary directly in the directory.
 
 You can run the binary with `./sshmux`. Note that you'll need to provide a valid configuration file as described [here](#config).
 
-You can perform the unit test with `go test` or `make test`. Enable verbose logging with `go test -v`.
+You can perform the unit tests with `go test` or `make test`. Enable verbose logging with `go test -v`.
 
 ## Config
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Build, Run and Test
 
-`sshmux` requires a Go 1.21+ toolchain to build. You can use `go build` or `make all` to get the `sshmux` binary directly in the directory.
+`sshmux` requires a Go 1.21+ toolchain to build. You can use `go build` or `make` to get the `sshmux` binary directly in the directory.
 
 You can run the binary with `./sshmux`. Note that you'll need to provide a valid configuration file as described [here](#config).
 
@@ -40,7 +40,7 @@ The table below shows extra options for `sshmux`, mainly for authentication with
 | `invalid-username`         | `[]string` | Usernames that are known to be invalid.                                    | `["user"]`                   |
 | `invalid-username-message` | `string`   | Message to display when the requested username is invalid.                 | `"Invalid username %s."`     |
 
-All of these options can be left empty or unset, if the corresponding feature is not intended to be used.
+All of these options can be omitted, if the corresponding feature is not intended to be used.
 
 ## API server
 
@@ -48,15 +48,15 @@ All of these options can be left empty or unset, if the corresponding feature is
 
 The API accepts JSON input with the following keys:
 
-| Key               | Type     | Description                                                                                            |
-|-------------------|----------|--------------------------------------------------------------------------------------------------------|
-| `auth_type`       | `string` | The authentication type. Always set to `"key"` at the moment.                                          |
-| `username`        | `string` | Vlab username. Unset if the user is authenticating with public key.                                    |
-| `password`        | `string` | Vlab password. Unset if the user is authenticating with public key.                                    |
-| `public_key_type` | `string` | SSH public key type. Unset if the user is authenticating with username and password.                   |
-| `public_key_data` | `string` | Base64-encoded SSH public key payload. Unset if the user is authenticating with username and password. |
-| `unix_username`   | `string` | UNIX username the user is requesting access to.                                                        |
-| `token`           | `string` | Token used to authenticate the `sshmux` instance.                                                      |
+| Key               | Type     | Description                                                                                              |
+|-------------------|----------|----------------------------------------------------------------------------------------------------------|
+| `auth_type`       | `string` | The authentication type. Always set to `"key"` at the moment.                                            |
+| `username`        | `string` | Vlab username. Omitted if the user is authenticating with public key.                                    |
+| `password`        | `string` | Vlab password. Omitted if the user is authenticating with public key.                                    |
+| `public_key_type` | `string` | SSH public key type. Omitted if the user is authenticating with username and password.                   |
+| `public_key_data` | `string` | Base64-encoded SSH public key payload. Omitted if the user is authenticating with username and password. |
+| `unix_username`   | `string` | UNIX username the user is requesting access to.                                                          |
+| `token`           | `string` | Token used to authenticate the `sshmux` instance.                                                        |
 
 The API responds with JSON output with the following keys:
 
@@ -67,4 +67,6 @@ The API responds with JSON output with the following keys:
 | `private_key`    | `string`  | SSH private key to authenticate for the downstream.                                                                  |
 | `cert`           | `string`  | The certificate associated with the SSH private key.                                                                 |
 | `vmid`           | `integer` | ID of the requested VM. Only used for recovery access.                                                               |
-| `proxy_protocol` | `integer` | PROXY protocol version to use for the downstream. Should be `1`, `2` or null values (which disables PROXY protocol). |
+| `proxy_protocol` | `integer` | PROXY protocol version to use for the downstream. Should be `1`, `2` or omitted (which disables PROXY protocol). |
+
+Note that if the user is not authorized, the API server should return a `status` other than `"ok"`, and other keys can be safely ommitted.

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ The table below shows the available options for `sshmux`:
 | Key         | Type       | Description                                                        | Required | Example                            |
 |-------------|------------|--------------------------------------------------------------------|----------|------------------------------------|
 | `address`   | `string`   | TCP host and port that `sshmux` will listen on.                    | `true`   | `"0.0.0.0:8022"`                   |
+| `host-keys` | `[]string` | Paths to SSH host key files with which `sshmux` identifies itself. | `true`   | `["/sshmux/ssh_host_ed25519_key"]` |
 | `api`       | `string`   | HTTP address that `sshmux` shall interact with.                    | `true`   | `"http://127.0.0.1:5000/ssh"`      |
 | `token`     | `string`   | Token used to authenticate with the API endpoint.                  | `true`   | `"long-and-random-token"`          |
 | `banner`    | `string`   | SSH banner to send to downstream.                                  | `false`  | `"Welcome to Vlab\n"`              |
 | `logger`    | `string`   | UDP host and port that `sshmux` send log messages to.              | `false`  | `"127.0.0.1:5556"`                 |
-| `host-keys` | `[]string` | Paths to SSH host key files with which `sshmux` identifies itself. | `true`   | `["/sshmux/ssh_host_ed25519_key"]` |
 | `proxy-protocol-allowed-cidrs` | `[]string` | CIDRs for which [PROXY protocol](https://www.haproxy.com/blog/use-the-proxy-protocol-to-preserve-a-clients-ip-address) is allowed. | `false` | `["127.0.0.22/32"]` |
 
 ### Advanced Config
@@ -53,9 +53,9 @@ The API accepts JSON input with the following keys:
 | `auth_type`       | `string` | The authentication type. Always set to `"key"` at the moment.                                          |
 | `username`        | `string` | Vlab username. Unset if the user is authenticating with public key.                                    |
 | `password`        | `string` | Vlab password. Unset if the user is authenticating with public key.                                    |
-| `unix_username`   | `string` | UNIX username the user is requesting access to.                                                        |
 | `public_key_type` | `string` | SSH public key type. Unset if the user is authenticating with username and password.                   |
 | `public_key_data` | `string` | Base64-encoded SSH public key payload. Unset if the user is authenticating with username and password. |
+| `unix_username`   | `string` | UNIX username the user is requesting access to.                                                        |
 | `token`           | `string` | Token used to authenticate the `sshmux` instance.                                                      |
 
 The API responds with JSON output with the following keys:

--- a/auth.go
+++ b/auth.go
@@ -12,12 +12,6 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-type RecoveryConfig struct {
-	Server   string   `json:"recovery-server"`
-	Username []string `json:"recovery-username"`
-	Token    string   `json:"token"`
-}
-
 type AuthRequestPublicKey struct {
 	AuthType      string `json:"auth_type"`
 	UnixUsername  string `json:"unix_username"`

--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+
+	"golang.org/x/crypto/ssh"
+)
+
+type AuthRequestPublicKey struct {
+	AuthType      string `json:"auth_type"`
+	UnixUsername  string `json:"unix_username"`
+	PublicKeyType string `json:"public_key_type"`
+	PublicKeyData string `json:"public_key_data"`
+	Token         string `json:"token"`
+}
+
+type AuthRequestPassword struct {
+	AuthType     string `json:"auth_type"`
+	Username     string `json:"username"`
+	Password     string `json:"password"`
+	UnixUsername string `json:"unix_username"`
+	Token        string `json:"token"`
+}
+
+type AuthResponse struct {
+	Status        string `json:"status"`
+	Address       string `json:"address"`
+	PrivateKey    string `json:"private_key"`
+	Cert          string `json:"cert"`
+	Id            int    `json:"vmid"`
+	ProxyProtocol byte   `json:"proxy_protocol,omitempty"`
+}
+
+type UpstreamInformation struct {
+	Host          string
+	Signer        ssh.Signer
+	Password      *string
+	ProxyProtocol byte
+}
+
+func parsePrivateKey(key string, cert string) ssh.Signer {
+	if key == "" {
+		return nil
+	}
+	signer, err := ssh.ParsePrivateKey([]byte(key))
+	if err != nil {
+		return nil
+	}
+	if cert == "" {
+		return signer
+	}
+	pk, _, _, _, err := ssh.ParseAuthorizedKey([]byte(cert))
+	if err != nil {
+		return signer
+	}
+	certSigner, err := ssh.NewCertSigner(pk.(*ssh.Certificate), signer)
+	if err != nil {
+		return signer
+	}
+	return certSigner
+}
+
+func authUser(request any, username string) (*UpstreamInformation, error) {
+	payload := new(bytes.Buffer)
+	if err := json.NewEncoder(payload).Encode(request); err != nil {
+		return nil, err
+	}
+	res, err := http.Post(config.API, "application/json", payload)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	var response AuthResponse
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return nil, err
+	}
+	if response.Status != "ok" {
+		return nil, nil
+	}
+
+	var upstream UpstreamInformation
+	if slices.Contains(config.RecoveryUsername, username) {
+		upstream.Host = config.RecoveryServer
+		password := fmt.Sprintf("%d %s", response.Id, config.Token)
+		upstream.Password = &password
+	} else {
+		upstream.Host = response.Address
+	}
+	upstream.Signer = parsePrivateKey(response.PrivateKey, response.Cert)
+	upstream.ProxyProtocol = response.ProxyProtocol
+	return &upstream, nil
+}
+
+func authUserWithPublicKey(key ssh.PublicKey, unixUsername string) (*UpstreamInformation, error) {
+	keyType := key.Type()
+	keyData := base64.StdEncoding.EncodeToString(key.Marshal())
+	request := &AuthRequestPublicKey{
+		AuthType:      "key",
+		UnixUsername:  unixUsername,
+		PublicKeyType: keyType,
+		PublicKeyData: keyData,
+		Token:         config.Token,
+	}
+	return authUser(request, unixUsername)
+}
+
+func authUserWithUserPass(username string, password string, unixUsername string) (*UpstreamInformation, error) {
+	request := &AuthRequestPassword{
+		AuthType:     "key",
+		Username:     username,
+		Password:     password,
+		UnixUsername: unixUsername,
+		Token:        config.Token,
+	}
+	return authUser(request, unixUsername)
+}
+
+func removePublicKeyMethod(methods []string) []string {
+	res := []string{}
+	for _, s := range methods {
+		if s != "publickey" {
+			res = append(res, s)
+		}
+	}
+	return res
+}

--- a/auth.go
+++ b/auth.go
@@ -55,6 +55,17 @@ type Authenticator struct {
 	Recovery RecoveryConfig
 }
 
+func makeAuthenticator(config Config) Authenticator {
+	return Authenticator{
+		Endpoint: config.API,
+		Recovery: RecoveryConfig{
+			Server:   config.RecoveryServer,
+			Username: config.RecoveryUsername,
+			Token:    config.Token,
+		},
+	}
+}
+
 func parsePrivateKey(key string, cert string) ssh.Signer {
 	if key == "" {
 		return nil

--- a/auth.go
+++ b/auth.go
@@ -144,7 +144,7 @@ func (auth Authenticator) AuthUserWithUserPass(username string, password string,
 }
 
 func removePublicKeyMethod(methods []string) []string {
-	res := []string{}
+	res := make([]string, 0, len(methods))
 	for _, s := range methods {
 		if s != "publickey" {
 			res = append(res, s)

--- a/auth.go
+++ b/auth.go
@@ -46,16 +46,22 @@ type UpstreamInformation struct {
 
 type Authenticator struct {
 	Endpoint string
+	Token    string
 	Recovery RecoveryConfig
 }
 
 func makeAuthenticator(config Config) Authenticator {
+	recoveryToken := config.RecoveryToken
+	if recoveryToken == "" {
+		recoveryToken = config.Token
+	}
 	return Authenticator{
 		Endpoint: config.API,
+		Token:    config.Token,
 		Recovery: RecoveryConfig{
 			Server:   config.RecoveryServer,
 			Username: config.RecoveryUsername,
-			Token:    config.Token,
+			Token:    recoveryToken,
 		},
 	}
 }
@@ -127,7 +133,7 @@ func (auth Authenticator) AuthUserWithPublicKey(key ssh.PublicKey, unixUsername 
 		UnixUsername:  unixUsername,
 		PublicKeyType: keyType,
 		PublicKeyData: keyData,
-		Token:         auth.Recovery.Token,
+		Token:         auth.Token,
 	}
 	return auth.AuthUser(request, unixUsername)
 }
@@ -138,7 +144,7 @@ func (auth Authenticator) AuthUserWithUserPass(username string, password string,
 		Username:     username,
 		Password:     password,
 		UnixUsername: unixUsername,
-		Token:        auth.Recovery.Token,
+		Token:        auth.Token,
 	}
 	return auth.AuthUser(request, unixUsername)
 }

--- a/config.go
+++ b/config.go
@@ -7,8 +7,9 @@ type Config struct {
 	API        string   `json:"api"`
 	Logger     string   `json:"logger"`
 	Banner     string   `json:"banner"`
+	Token      string   `json:"token"`
 	// The following should be moved into API server
-	Token                  string   `json:"token"`
+	RecoveryToken          string   `json:"recovery-token"`
 	RecoveryServer         string   `json:"recovery-server"`
 	RecoveryUsername       []string `json:"recovery-username"`
 	AllUsernameNoPassword  bool     `json:"all-username-nopassword"`

--- a/config.go
+++ b/config.go
@@ -1,0 +1,34 @@
+package main
+
+type Config struct {
+	Address    string   `json:"address"`
+	ProxyCIDRs []string `json:"proxy-protocol-allowed-cidrs"`
+	HostKeys   []string `json:"host-keys"`
+	API        string   `json:"api"`
+	Logger     string   `json:"logger"`
+	Banner     string   `json:"banner"`
+	// The following should be moved into API server
+	Token                  string   `json:"token"`
+	RecoveryServer         string   `json:"recovery-server"`
+	RecoveryUsername       []string `json:"recovery-username"`
+	AllUsernameNoPassword  bool     `json:"all-username-nopassword"`
+	UsernameNoPassword     []string `json:"username-nopassword"`
+	InvalidUsername        []string `json:"invalid-username"`
+	InvalidUsernameMessage string   `json:"invalid-username-message"`
+}
+
+type UsernamePolicyConfig struct {
+	InvalidUsername        []string `json:"invalid-username"`
+	InvalidUsernameMessage string   `json:"invalid-username-message"`
+}
+
+type PasswordPolicyConfig struct {
+	AllUsernameNoPassword bool     `json:"all-username-nopassword"`
+	UsernameNoPassword    []string `json:"username-nopassword"`
+}
+
+type RecoveryConfig struct {
+	Server   string   `json:"recovery-server"`
+	Username []string `json:"recovery-username"`
+	Token    string   `json:"token"`
+}

--- a/logging.go
+++ b/logging.go
@@ -22,6 +22,10 @@ type Logger struct {
 func makeLogger(url string) Logger {
 	channel := make(chan LogMessage, 256)
 	go func() {
+		if url == "" {
+			for range channel {
+			}
+		}
 		conn, err := net.Dial("udp", url)
 		if err != nil {
 			log.Printf("Logger Dial failed: %s\n", err)

--- a/logging.go
+++ b/logging.go
@@ -40,7 +40,7 @@ func makeLogger(url string) Logger {
 	return Logger{Channel: channel}
 }
 
-func (l Logger) sendLog(logMessage *LogMessage) {
+func (l Logger) SendLog(logMessage *LogMessage) {
 	logMessage.DisconnectTime = time.Now().Unix()
 	l.Channel <- *logMessage
 }

--- a/logging.go
+++ b/logging.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+type LogMessage struct {
+	LoginTime      int64  `json:"login_time"`
+	DisconnectTime int64  `json:"disconnect_time"`
+	ClientIp       string `json:"remote_ip"`
+	HostIp         string `json:"host_ip"`
+	Username       string `json:"user_name"`
+}
+
+func runLogger(logger string, ch <-chan LogMessage) {
+	conn, err := net.Dial("udp", logger)
+	if err != nil {
+		log.Printf("Logger Dial failed: %s\n", err)
+		// Drain the channel to avoid blocking
+		for range ch {
+		}
+	}
+	for logMessage := range ch {
+		jsonMsg, err := json.Marshal(logMessage)
+		if err != nil {
+			continue
+		}
+		conn.Write(jsonMsg)
+	}
+}
+
+func sendLogAndClose(logMessage *LogMessage, session *ssh.PipeSession, logCh chan<- LogMessage) {
+	session.Close()
+	logMessage.DisconnectTime = time.Now().Unix()
+	logCh <- *logMessage
+}

--- a/logging.go
+++ b/logging.go
@@ -25,6 +25,7 @@ func makeLogger(url string) Logger {
 		if url == "" {
 			for range channel {
 			}
+			return
 		}
 		conn, err := net.Dial("udp", url)
 		if err != nil {
@@ -32,6 +33,7 @@ func makeLogger(url string) Logger {
 			// Drain the channel to avoid blocking
 			for range channel {
 			}
+			return
 		}
 		for logMessage := range channel {
 			jsonMsg, err := json.Marshal(logMessage)

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ func sshmuxServer(configFile string) {
 }
 
 func main() {
+	var configFile string
 	flag.StringVar(&configFile, "c", "/etc/sshmux/config.json", "config file")
 	flag.Parse()
 	sshmuxServer(configFile)

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 )
 
 func sshmuxServer(configFile string) {
+	var config Config
 	configFileBytes, err := os.ReadFile(configFile)
 	if err != nil {
 		log.Fatal(err)
@@ -42,7 +43,7 @@ func sshmuxServer(configFile string) {
 		}
 		proxyUpstreams = append(proxyUpstreams, network)
 	}
-	sshmuxListenAddr(config.Address, sshConfig, proxyUpstreams)
+	sshmuxListenAddr(config.Address, sshConfig, proxyUpstreams, config)
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -4,10 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"log"
-	"net/netip"
 	"os"
-
-	"golang.org/x/crypto/ssh"
 )
 
 func sshmuxServer(configFile string) {
@@ -20,30 +17,11 @@ func sshmuxServer(configFile string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	sshConfig := &ssh.ServerConfig{
-		ServerVersion:           "SSH-2.0-taokystrong",
-		PublicKeyAuthAlgorithms: ssh.DefaultPubKeyAuthAlgos(),
+	sshmux, err := makeServer(config)
+	if err != nil {
+		log.Fatal(err)
 	}
-	for _, keyFile := range config.HostKeys {
-		bytes, err := os.ReadFile(keyFile)
-		if err != nil {
-			log.Fatal(err)
-		}
-		key, err := ssh.ParsePrivateKey(bytes)
-		if err != nil {
-			log.Fatal(err)
-		}
-		sshConfig.AddHostKey(key)
-	}
-	proxyUpstreams := make([]netip.Prefix, 0)
-	for _, cidr := range config.ProxyCIDRs {
-		network, err := netip.ParsePrefix(cidr)
-		if err != nil {
-			log.Fatal(err)
-		}
-		proxyUpstreams = append(proxyUpstreams, network)
-	}
-	sshmuxListenAddr(config.Address, sshConfig, proxyUpstreams, config)
+	sshmux.ListenAddr(config.Address)
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"log"
+	"net/netip"
+	"os"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func sshmuxServer(configFile string) {
+	configFileBytes, err := os.ReadFile(configFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = json.Unmarshal(configFileBytes, &config)
+	if err != nil {
+		log.Fatal(err)
+	}
+	sshConfig := &ssh.ServerConfig{
+		ServerVersion:           "SSH-2.0-taokystrong",
+		PublicKeyAuthAlgorithms: ssh.DefaultPubKeyAuthAlgos(),
+	}
+	for _, keyFile := range config.HostKeys {
+		bytes, err := os.ReadFile(keyFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		key, err := ssh.ParsePrivateKey(bytes)
+		if err != nil {
+			log.Fatal(err)
+		}
+		sshConfig.AddHostKey(key)
+	}
+	proxyUpstreams := make([]netip.Prefix, 0)
+	for _, cidr := range config.ProxyCIDRs {
+		network, err := netip.ParsePrefix(cidr)
+		if err != nil {
+			log.Fatal(err)
+		}
+		proxyUpstreams = append(proxyUpstreams, network)
+	}
+	sshmuxListenAddr(config.Address, sshConfig, proxyUpstreams)
+}
+
+func main() {
+	flag.StringVar(&configFile, "c", "/etc/sshmux/config.json", "config file")
+	flag.Parse()
+	sshmuxServer(configFile)
+}

--- a/sshmux.go
+++ b/sshmux.go
@@ -270,7 +270,7 @@ func (s *Server) ListenAddr(address string) error {
 			}
 			defer func() {
 				session.Close()
-				s.Logger.sendLog(&logMessage)
+				s.Logger.SendLog(&logMessage)
 			}()
 			if err := s.RunPipeSession(session, &logMessage); err != nil {
 				log.Println("runPipeSession:", err)

--- a/sshmux.go
+++ b/sshmux.go
@@ -47,6 +47,12 @@ func handshake(config Config, session *ssh.PipeSession) error {
 			return err
 		}
 	}
+	// Compose RecoveryConfig
+	recoveryConfig := RecoveryConfig{
+		Server:   config.RecoveryServer,
+		Username: config.RecoveryUsername,
+		Token:    config.Token,
+	}
 	// Stage 1: Get publickey or keyboard-interactive answers, and authenticate the user with with API
 	for {
 		req, err := session.Downstream.ReadAuthRequest(true)
@@ -67,7 +73,7 @@ func handshake(config Config, session *ssh.PipeSession) error {
 		if req.Method == "none" {
 			session.Downstream.WriteAuthFailure([]string{"publickey", "keyboard-interactive"}, false)
 		} else if req.Method == "publickey" && !req.IsPublicKeyQuery {
-			upstream, err = authUserWithPublicKey(*req.PublicKey, user, config)
+			upstream, err = authUserWithPublicKey(*req.PublicKey, user, config.API, recoveryConfig)
 			if err != nil {
 				return err
 			}
@@ -93,7 +99,7 @@ func handshake(config Config, session *ssh.PipeSession) error {
 			}
 			username := answers[0]
 			password := answers[1]
-			upstream, err = authUserWithUserPass(username, password, user, config)
+			upstream, err = authUserWithUserPass(username, password, user, config.API, recoveryConfig)
 			if err != nil {
 				return err
 			}

--- a/sshmux.go
+++ b/sshmux.go
@@ -37,7 +37,6 @@ type LogMessage struct {
 	Username       string `json:"user_name"`
 }
 
-var configFile string
 var config Config
 
 func handshake(session *ssh.PipeSession) error {

--- a/sshmux.go
+++ b/sshmux.go
@@ -1,17 +1,11 @@
 package main
 
 import (
-	"bytes"
-	"encoding/base64"
 	"encoding/json"
-	"flag"
 	"fmt"
-	"io"
 	"log"
 	"net"
-	"net/http"
 	"net/netip"
-	"os"
 	"slices"
 	"time"
 
@@ -45,130 +39,6 @@ type LogMessage struct {
 
 var configFile string
 var config Config
-
-type AuthRequestPublicKey struct {
-	AuthType      string `json:"auth_type"`
-	UnixUsername  string `json:"unix_username"`
-	PublicKeyType string `json:"public_key_type"`
-	PublicKeyData string `json:"public_key_data"`
-	Token         string `json:"token"`
-}
-
-type AuthRequestPassword struct {
-	AuthType     string `json:"auth_type"`
-	Username     string `json:"username"`
-	Password     string `json:"password"`
-	UnixUsername string `json:"unix_username"`
-	Token        string `json:"token"`
-}
-
-type AuthResponse struct {
-	Status        string `json:"status"`
-	Address       string `json:"address"`
-	PrivateKey    string `json:"private_key"`
-	Cert          string `json:"cert"`
-	Id            int    `json:"vmid"`
-	ProxyProtocol byte   `json:"proxy_protocol,omitempty"`
-}
-
-type UpstreamInformation struct {
-	Host          string
-	Signer        ssh.Signer
-	Password      *string
-	ProxyProtocol byte
-}
-
-func parsePrivateKey(key string, cert string) ssh.Signer {
-	if key == "" {
-		return nil
-	}
-	signer, err := ssh.ParsePrivateKey([]byte(key))
-	if err != nil {
-		return nil
-	}
-	if cert == "" {
-		return signer
-	}
-	pk, _, _, _, err := ssh.ParseAuthorizedKey([]byte(cert))
-	if err != nil {
-		return signer
-	}
-	certSigner, err := ssh.NewCertSigner(pk.(*ssh.Certificate), signer)
-	if err != nil {
-		return signer
-	}
-	return certSigner
-}
-
-func authUser(request any, username string) (*UpstreamInformation, error) {
-	payload := new(bytes.Buffer)
-	if err := json.NewEncoder(payload).Encode(request); err != nil {
-		return nil, err
-	}
-	res, err := http.Post(config.API, "application/json", payload)
-	if err != nil {
-		return nil, err
-	}
-	defer res.Body.Close()
-	body, err := io.ReadAll(res.Body)
-	if err != nil {
-		return nil, err
-	}
-	var response AuthResponse
-	err = json.Unmarshal(body, &response)
-	if err != nil {
-		return nil, err
-	}
-	if response.Status != "ok" {
-		return nil, nil
-	}
-
-	var upstream UpstreamInformation
-	if slices.Contains(config.RecoveryUsername, username) {
-		upstream.Host = config.RecoveryServer
-		password := fmt.Sprintf("%d %s", response.Id, config.Token)
-		upstream.Password = &password
-	} else {
-		upstream.Host = response.Address
-	}
-	upstream.Signer = parsePrivateKey(response.PrivateKey, response.Cert)
-	upstream.ProxyProtocol = response.ProxyProtocol
-	return &upstream, nil
-}
-
-func authUserWithPublicKey(key ssh.PublicKey, unixUsername string) (*UpstreamInformation, error) {
-	keyType := key.Type()
-	keyData := base64.StdEncoding.EncodeToString(key.Marshal())
-	request := &AuthRequestPublicKey{
-		AuthType:      "key",
-		UnixUsername:  unixUsername,
-		PublicKeyType: keyType,
-		PublicKeyData: keyData,
-		Token:         config.Token,
-	}
-	return authUser(request, unixUsername)
-}
-
-func authUserWithUserPass(username string, password string, unixUsername string) (*UpstreamInformation, error) {
-	request := &AuthRequestPassword{
-		AuthType:     "key",
-		Username:     username,
-		Password:     password,
-		UnixUsername: unixUsername,
-		Token:        config.Token,
-	}
-	return authUser(request, unixUsername)
-}
-
-func removePublicKeyMethod(methods []string) []string {
-	res := []string{}
-	for _, s := range methods {
-		if s != "publickey" {
-			res = append(res, s)
-		}
-	}
-	return res
-}
 
 func handshake(session *ssh.PipeSession) error {
 	hasSetUser := false
@@ -415,45 +285,4 @@ func sshmuxListenAddr(address string, sshConfig *ssh.ServerConfig, proxyUpstream
 			}
 		}()
 	}
-}
-
-func sshmuxServer(configFile string) {
-	configFileBytes, err := os.ReadFile(configFile)
-	if err != nil {
-		log.Fatal(err)
-	}
-	err = json.Unmarshal(configFileBytes, &config)
-	if err != nil {
-		log.Fatal(err)
-	}
-	sshConfig := &ssh.ServerConfig{
-		ServerVersion:           "SSH-2.0-taokystrong",
-		PublicKeyAuthAlgorithms: ssh.DefaultPubKeyAuthAlgos(),
-	}
-	for _, keyFile := range config.HostKeys {
-		bytes, err := os.ReadFile(keyFile)
-		if err != nil {
-			log.Fatal(err)
-		}
-		key, err := ssh.ParsePrivateKey(bytes)
-		if err != nil {
-			log.Fatal(err)
-		}
-		sshConfig.AddHostKey(key)
-	}
-	proxyUpstreams := make([]netip.Prefix, 0)
-	for _, cidr := range config.ProxyCIDRs {
-		network, err := netip.ParsePrefix(cidr)
-		if err != nil {
-			log.Fatal(err)
-		}
-		proxyUpstreams = append(proxyUpstreams, network)
-	}
-	sshmuxListenAddr(config.Address, sshConfig, proxyUpstreams)
-}
-
-func main() {
-	flag.StringVar(&configFile, "c", "/etc/sshmux/config.json", "config file")
-	flag.Parse()
-	sshmuxServer(configFile)
 }


### PR DESCRIPTION
This PR intends to re-organize all the codes into different "submodules". Most notably, it removes all global variables and wraps all the functionalities into classes with minor changes to the behavior, enabling more precise testing. `recovery-token` is added as an optional configuration, and `logger` is no longer required.

This PR also adds a concrete README on all the configurable options and the API design.