### PR TITLE
Add support for Docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/ustc-vlab/sshmux            
+          images: ghcr.io/ustc-vlab/sshmux
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,3 +41,35 @@ jobs:
           sshmux
           config.example.json
           sshmux.service
+  docker:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compute Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/ustc-vlab/sshmux            
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=sha
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          push: ${{ startsWith(github.ref, 'refs/tags/') }}
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,10 +42,10 @@ jobs:
           config.example.json
           sshmux.service
   docker:
-    name: Build Docker image
+    name: Docker
     runs-on: ubuntu-latest
     steps:
-      - name: Compute Docker meta
+      - name: Compute Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -54,7 +54,6 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
-            type=sha
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.22 AS build
+
+WORKDIR /go/src/app
+COPY . .
+
+RUN go mod download
+RUN CGO_ENABLED=0 go build -o /go/bin/sshmux
+
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=build /go/bin/sshmux /
+CMD ["/sshmux"]


### PR DESCRIPTION
This PR adds a `Dockerfile` based on [Distroless](https://github.com/GoogleContainerTools/distroless), and tweaks the "build" workflow to build Docker image also.