### PR TITLE
Close pipe channel bidirectionally

### DIFF
--- a/crypto/ssh/pipe.go
+++ b/crypto/ssh/pipe.go
@@ -458,9 +458,11 @@ func pipe(dst, src packetConn) error {
 func (s *PipeSession) RunPipe() error {
 	c := make(chan error)
 	go func() {
+		defer s.Downstream.transport.Close()
 		c <- pipe(s.Downstream.transport, s.Upstream.transport)
 	}()
 	go func() {
+		defer s.Upstream.transport.Close()
 		c <- pipe(s.Upstream.transport, s.Downstream.transport)
 	}()
 	return <-c


### PR DESCRIPTION
A small improvement to kill upstream/downstream connection immediately when the reverse connection is killed. Before the change, the active side will need to send a packet to trigger the kill.