### PR TITLE
Make `Server` awaitable and cancellable

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,11 +7,11 @@ import (
 	"os"
 )
 
-func sshmuxServer(configFile string) {
+func sshmuxServer(configFile string) (*Server, error) {
 	var config Config
 	configFileBytes, err := os.ReadFile(configFile)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	err = json.Unmarshal(configFileBytes, &config)
 	if err != nil {
@@ -19,14 +19,22 @@ func sshmuxServer(configFile string) {
 	}
 	sshmux, err := makeServer(config)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
-	sshmux.ListenAddr(config.Address)
+	return sshmux, nil
 }
 
 func main() {
 	var configFile string
 	flag.StringVar(&configFile, "c", "/etc/sshmux/config.json", "config file")
 	flag.Parse()
-	sshmuxServer(configFile)
+	sshmux, err := sshmuxServer(configFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = sshmux.Start()
+	if err != nil {
+		log.Fatal(err)
+	}
+	sshmux.Wait()
 }

--- a/sshmux_test.go
+++ b/sshmux_test.go
@@ -246,7 +246,17 @@ func TestSSHClientConnection(t *testing.T) {
 
 	initEnv(t, baseDir)
 	privateKeyPath := filepath.Join(baseDir, "example_rsa")
-	go sshmuxServer("etc/config.example.json")
+
+	// start sshmux server
+	sshmux, err := sshmuxServer("etc/config.example.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = sshmux.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sshmux.Shutdown()
 
 	// sanity check
 	testWithSSHClient(t, sshdServerAddr, "sanity check", false, baseDir, privateKeyPath)


### PR DESCRIPTION
This PR (finally) makes `Server` fully testable and introduces graceful shutdown support. This enables more fine-grained control over the server, and also enables starting multiple `Server` instances in parallel.