### PR TITLE
RESTful API for authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,24 +45,34 @@ Auth settings configures the authentication and authorization API used by `sshmu
 
 #### Legacy Auth Settings
 
-The following settings are only used with `legacy` auth APIs. They are also grouped under `auth` in the TOML file.
+The following settings are only used by `legacy` auth APIs. They are also grouped under `auth` in the TOML file.
 
-| Key                        | Type       | Description                                                 | Required                   | Example                      |
-| -------------------------- | ---------- | ----------------------------------------------------------- | -------------------------- | ---------------------------- |
-| `token`                    | `string`   | Token used to authenticate with the API endpoint.           | If `version` is `"legacy"` | `"long-and-random-token"`    |
-| `all-username-nopassword`  | `bool`     | If set to `true`, no users will be asked for UNIX password. | No                         | `true`                       |
-| `usernames-nopassword`     | `[]string` | Usernames that won't be asked for UNIX password.            | No                         | `["vlab", "ubuntu", "root"]` |
-| `invalid-usernames`        | `[]string` | Usernames that are known to be invalid.                     | No                         | `["user"]`                   |
-| `invalid-username-message` | `string`   | Message to display when the requested username is invalid.  | No                         | `"Invalid username %s."`     |
+| Key                        | Type       | Description                                                 | Required                        | Example                      |
+| -------------------------- | ---------- | ----------------------------------------------------------- | ------------------------------- | ---------------------------- |
+| `token`                    | `string`   | Token used to authenticate with the API endpoint.           | If `auth.version` is `"legacy"` | `"long-and-random-token"`    |
+| `all-username-nopassword`  | `bool`     | If set to `true`, no users will be asked for UNIX password. | No                              | `true`                       |
+| `usernames-nopassword`     | `[]string` | Usernames that won't be asked for UNIX password.            | No                              | `["vlab", "ubuntu", "root"]` |
+| `invalid-usernames`        | `[]string` | Usernames that are known to be invalid.                     | No                              | `["user"]`                   |
+| `invalid-username-message` | `string`   | Message to display when the requested username is invalid.  | No                              | `"Invalid username %s."`     |
+
+#### Recovery Settings
+
+Recovery settings configures Vlab recovery service support of `sshmux` for `legacy` auth APIs. They are grouped under `recovery` in the TOML file.
+
+| Key         | Type       | Description                                           | Required | Example                   |
+| ----------- | ---------- | ----------------------------------------------------- | -------- | ------------------------- |
+| `address`   | `string`   | SSH host and port of the recovery server.             | No       | `"172.30.0.101:2222"`     |
+| `usernames` | `[]string` | Usernames dedicated to the recovery server.           | No       | `["recovery", "console"]` |
+| `token`     | `string`   | Token used to authenticate with the recovery backend. | No       | `"long-and-random-token"` |
 
 ### Logger Settings
 
 Logger settings configures the logger behavior of `sshmux`. They are grouped under `logger` in the TOML file.
 
-| Key        | Type     | Description                                                                   | Required               | Example                  |
-| ---------- | -------- | ----------------------------------------------------------------------------- | ---------------------- | ------------------------ |
-| `enabled`  | `bool`   | Whether the logger is enabled. Defaults to `false`.                           | No                     | `true`                   |
-| `endpoint` | `string` | Endpoint URL that `sshmux` will log onto. Only `udp` scheme is supported now. | If `enabled` is `true` | `"udp://127.0.0.1:5556"` |
+| Key        | Type     | Description                                                                   | Required                      | Example                  |
+| ---------- | -------- | ----------------------------------------------------------------------------- | ----------------------------- | ------------------------ |
+| `enabled`  | `bool`   | Whether the logger is enabled. Defaults to `false`.                           | No                            | `true`                   |
+| `endpoint` | `string` | Endpoint URL that `sshmux` will log onto. Only `udp` scheme is supported now. | If `logger.enabled` is `true` | `"udp://127.0.0.1:5556"` |
 
 ### PROXY Protocol Settings
 
@@ -73,16 +83,6 @@ PROXY protocol settings configures [PROXY protocol](https://www.haproxy.com/blog
 | `enabled`  | `bool`     | Whether PROXY protocol support is enabled. Defaults to `false`. | No       | `true`                          |
 | `hosts`    | `[]string` | Host names from which PROXY protocol is allowed.                | No       | `["nginx.local", "127.0.0.22"]` |
 | `networks` | `[]string` | Network CIDRs from which PROXY protocol is allowed.             | No       | `["10.10.0.0/24"]`              |
-
-### Recovery Settings
-
-Recovery settings configures Vlab recovery service support of `sshmux`. They are grouped under `recovery` in the TOML file.
-
-| Key         | Type       | Description                                           | Required | Example                   |
-| ----------- | ---------- | ----------------------------------------------------- | -------- | ------------------------- |
-| `address`   | `string`   | SSH host and port of the recovery server.             | No       | `"172.30.0.101:2222"`     |
-| `usernames` | `[]string` | Usernames dedicated to the recovery server.           | No       | `["recovery", "console"]` |
-| `token`     | `string`   | Token used to authenticate with the recovery backend. | No       | `"long-and-random-token"` |
 
 ## Auth API
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ SSH settings configure the integrated SSH server in `sshmux`. They are grouped u
 
 Auth settings configures the authentication and authorization API used by `sshmux`. They are grouped under `auth` in the TOML file.
 
-| Key        | Type     | Description                                                                | Required | Example                       |
-| ---------- | -------- | -------------------------------------------------------------------------- | -------- | ----------------------------- |
-| `endpoint` | `string` | Endpoint URL that `sshmux` will use for authentication and authorization.  | Yes      | `"http://127.0.0.1:5000/ssh"` |
-| `version`  | `string` | Auth endpoint API version (`legacy`, `v1`). Defaults to `legacy`.          | No       | `"v1"`                        |
+| Key        | Type           | Description                                                                | Required | Example                                            |
+| ---------- | -------------- | -------------------------------------------------------------------------- | -------- | -------------------------------------------------- |
+| `endpoint` | `string`       | Endpoint URL that `sshmux` will use for authentication and authorization.  | Yes      | `"http://127.0.0.1:5000/ssh"`                      |
+| `version`  | `string`       | Auth endpoint API version (`legacy`, `v1`). Defaults to `legacy`.          | No       | `"v1"`                                             |
+| `headers`  | `[]HTTPHeader` | Extra HTTP headers to send to API server.                                  | No       | See [`fixtures/config.toml`](fixtures/config.toml) |
 
 #### Legacy Auth Settings
 

--- a/README.md
+++ b/README.md
@@ -92,69 +92,69 @@ Recovery settings configures Vlab recovery service support of `sshmux`. They are
 
 #### Input
 
-| Key               | Type                  | Description                                                                                    | Position | Optional |
+| Key               | Type                  | Description                                                                                    | Position | Required |
 | ----------------- | --------------------- | ---------------------------------------------------------------------------------------------- | -------- | -------- |
-| `username`        | `string`              | SSH user name. Usually the one for logging into the target server.                             | Path     | No       |
-| `method`          | `string`              | SSH authentication method. Usually one of `"none"`, `"publickey"` or `"keyboard-interactive"`. | Body     | No       |
-| `public_key`      | `string`              | User public key, serialized in OpenSSH format.                                                 | Body     | Yes      |
-| `payload`         | `Map<string, string>` | Authentication payload constructed from interactive input.                                     | Body     | Yes      |
+| `username`        | `string`              | SSH user name. Usually the one for logging into the target server.                             | Path     | Yes      |
+| `method`          | `string`              | SSH authentication method. Usually one of `"none"`, `"publickey"` or `"keyboard-interactive"`. | Body     | Yes      |
+| `public_key`      | `string`              | User public key, serialized in OpenSSH format.                                                 | Body     | No       |
+| `payload`         | `Map<string, string>` | Authentication payload constructed from interactive input.                                     | Body     | No       |
 
 #### Output: `200 OK`
 
-| Key              | Type                    | Description                   | Optional |
+| Key              | Type                    | Description                   | Required |
 | ---------------- | ----------------------- | ----------------------------- | -------- |
-| `upstream`       | [`Upstream`](#upstream) | SSH upstream information.     | No       |
-| `proxy`          | [`Proxy`](#proxy)       | PROXY protocol configuration. | Yes      |
+| `upstream`       | [`Upstream`](#upstream) | SSH upstream information.     | Yes      |
+| `proxy`          | [`Proxy`](#proxy)       | PROXY protocol configuration. | No       |
 
 ##### `Upstream`
 
-| Key           | Type     | Description                                                                 | Optional |
+| Key           | Type     | Description                                                                 | Required |
 | ------------- | -------- | --------------------------------------------------------------------------- | -------- |
-| `host`        | `string` | Host name or IP of upstream SSH server.                                     | No       |
-| `port`        | `uint`   | Port number of upstream SSH server. Defaults to `22`.                       | Yes      |
-| `private_key` | `string` | Private key for authenticating with upstream, serialized in OpenSSH format. | Yes      |
-| `certificate` | `string` | Certificate for authenticating with upstream, serialized in OpenSSH format. | Yes      |
-| `password`    | `string` | Password for authenticating with upstream.                                  | Yes      |
+| `host`        | `string` | Host name or IP of upstream SSH server.                                     | Yes      |
+| `port`        | `uint`   | Port number of upstream SSH server. Defaults to `22`.                       | No       |
+| `private_key` | `string` | Private key for authenticating with upstream, serialized in OpenSSH format. | No       |
+| `certificate` | `string` | Certificate for authenticating with upstream, serialized in OpenSSH format. | No       |
+| `password`    | `string` | Password for authenticating with upstream.                                  | No       |
 
 ##### `Proxy`
 
-| Key           | Type     | Description                                                                         | Optional |
+| Key           | Type     | Description                                                                         | Required |
 | ------------- | -------- | ----------------------------------------------------------------------------------- | -------- |
-| `host`        | `string` | Host name or IP of the proxy server. Defaults to `upstream.host`.                   | Yes      |
-| `port`        | `uint`   | Port number of the proxy server. Defaults to `upstream.port`.                       | Yes      |
-| `protocol`    | `string` | PROXY protocol version to use. Must be one of `"v1"` or `"v2"`. Defaults to `"v2"`. | Yes      |
+| `host`        | `string` | Host name or IP of the proxy server. Defaults to `upstream.host`.                   | No       |
+| `port`        | `uint`   | Port number of the proxy server. Defaults to `upstream.port`.                       | No       |
+| `protocol`    | `string` | PROXY protocol version to use. Must be one of `"v1"` or `"v2"`. Defaults to `"v2"`. | No       |
 
 #### Output: `401 Not Authorized`
 
-| Key          | Type                        | Description                                                                                      | Optional |
+| Key          | Type                        | Description                                                                                      | Required |
 | ------------ | --------------------------- | ------------------------------------------------------------------------------------------------ | -------- |
-| `challenges` | [`[]Challenge`](#challenge) | Challenges for extra inputs from user. Only applicable to `keyboard-interactive` authentication. | No       |
+| `challenges` | [`[]Challenge`](#challenge) | Challenges for extra inputs from user. Only applicable to `keyboard-interactive` authentication. | Yes      |
 
 ##### `Challenge`
 
-| Key           | Type                                  | Description                        | Optional |
+| Key           | Type                                  | Description                        | Required |
 | ------------- | ------------------------------------- | ---------------------------------- | -------- |
-| `instruction` | `string`                              | Instruction for the challenge.     | No       |
-| `fields`      | [`[]ChallengeField`](#challengefield) | Requested fields by the challenge. | Yes      |
+| `instruction` | `string`                              | Instruction for the challenge.     | Yes      |
+| `fields`      | [`[]ChallengeField`](#challengefield) | Requested fields by the challenge. | No       |
 
 ##### `ChallengeField`
 
-| Key      | Type     | Description                                                | Optional |
+| Key      | Type     | Description                                                | Required |
 | -------- | -------- | ---------------------------------------------------------- | -------- |
-| `key`    | `string` | Key to set the user input on.                              | No       |
-| `prompt` | `string` | Prompt for the input field.                                | No       |
-| `secret` | `bool`   | Whether to treat the input as secret. Defaults to `false`. | Yes      |
+| `key`    | `string` | Key to set the user input on.                              | Yes      |
+| `prompt` | `string` | Prompt for the input field.                                | Yes      |
+| `secret` | `bool`   | Whether to treat the input as secret. Defaults to `false`. | No       |
 
 #### Output: `403 Forbidden`
 
-| Key       | Type                  | Description               | Optional |
+| Key       | Type                  | Description               | Required |
 | --------- | --------------------- | ------------------------- | -------- |
-| `failure` | [`Failure`](#failure) | Auth failure information. | Yes      |
+| `failure` | [`Failure`](#failure) | Auth failure information. | No       |
 
 ##### `Failure`
 
-| Key          | Type     | Description                                                                 | Optional |
+| Key          | Type     | Description                                                                 | Required |
 | ------------ | -------- | --------------------------------------------------------------------------- | -------- |
-| `message`    | `string` | Message from the server to describe the failure.                            | No       |
-| `disconnect` | `string` | Whether to disconnect the downstream user. Defaults to `false`.             | Yes      |
-| `reason`     | `uint`   | SSH disconnect reason code. Defaults to `11` (`DISCONNECT_BY_APPLICATION`). | Yes      |
+| `message`    | `string` | Message from the server to describe the failure.                            | Yes      |
+| `disconnect` | `string` | Whether to disconnect the downstream user. Defaults to `false`.             | No       |
+| `reason`     | `uint`   | SSH disconnect reason code. Defaults to `11` (`DISCONNECT_BY_APPLICATION`). | No       |

--- a/README.md
+++ b/README.md
@@ -37,14 +37,22 @@ SSH settings configure the integrated SSH server in `sshmux`. They are grouped u
 
 Auth settings configures the authentication and authorization API used by `sshmux`. They are grouped under `auth` in the TOML file.
 
-| Key                        | Type       | Description                                                                | Required | Example                       |
-| -------------------------- | ---------- | -------------------------------------------------------------------------- | -------- | ----------------------------- |
-| `endpoint`                 | `string`   | Endpoint URL that `sshmux` will use for authentication and authorization.  | Yes      | `"http://127.0.0.1:5000/ssh"` |
-| `token`                    | `string`   | Token used to authenticate with the API endpoint.                          | Yes      | `"long-and-random-token"`     |
-| `all-username-nopassword`  | `bool`     | If set to `true`, no users will be asked for UNIX password.                | No       | `true`                        |
-| `usernames-nopassword`     | `[]string` | Usernames that won't be asked for UNIX password.                           | No       | `["vlab", "ubuntu", "root"]`  |
-| `invalid-usernames`        | `[]string` | Usernames that are known to be invalid.                                    | No       | `["user"]`                    |
-| `invalid-username-message` | `string`   | Message to display when the requested username is invalid.                 | No       | `"Invalid username %s."`      |
+| Key        | Type     | Description                                                                | Required | Example                       |
+| ---------- | -------- | -------------------------------------------------------------------------- | -------- | ----------------------------- |
+| `endpoint` | `string` | Endpoint URL that `sshmux` will use for authentication and authorization.  | Yes      | `"http://127.0.0.1:5000/ssh"` |
+| `version`  | `string` | Auth endpoint API version (`legacy`, `v1`). Defaults to `legacy`.          | No       | `"v1"`                        |
+
+#### Legacy Auth Settings
+
+The following settings are only used with `legacy` auth APIs. They are also grouped under `auth` in the TOML file.
+
+| Key                        | Type       | Description                                                 | Required                 | Example                      |
+| -------------------------- | ---------- | ----------------------------------------------------------- | ------------------------ | ---------------------------- |
+| `token`                    | `string`   | Token used to authenticate with the API endpoint.           | If `version` is `legacy` | `"long-and-random-token"`    |
+| `all-username-nopassword`  | `bool`     | If set to `true`, no users will be asked for UNIX password. | No                       | `true`                       |
+| `usernames-nopassword`     | `[]string` | Usernames that won't be asked for UNIX password.            | No                       | `["vlab", "ubuntu", "root"]` |
+| `invalid-usernames`        | `[]string` | Usernames that are known to be invalid.                     | No                       | `["user"]`                   |
+| `invalid-username-message` | `string`   | Message to display when the requested username is invalid.  | No                       | `"Invalid username %s."`     |
 
 ### Logger Settings
 

--- a/auth.go
+++ b/auth.go
@@ -41,6 +41,7 @@ type AuthFailure struct {
 
 type AuthUpstream struct {
 	Host          string  `json:"host"`
+	Port          uint16  `json:"port,omitempty"`
 	PrivateKey    string  `json:"private_key,omitempty"`
 	Certificate   string  `json:"certificate,omitempty"`
 	Password      *string `json:"password,omitempty"`

--- a/auth.go
+++ b/auth.go
@@ -2,11 +2,45 @@ package main
 
 import "golang.org/x/crypto/ssh"
 
-type UpstreamInformation struct {
-	Host          string
-	Signer        ssh.Signer
-	Password      *string
-	ProxyProtocol byte
+type AuthRequest struct {
+	Method    string            `json:"method"`
+	PublicKey string            `json:"public_key,omitempty"`
+	Payload   map[string]string `json:"payload"`
+}
+
+type AuthResponse struct {
+	Challenges []AuthChallenge `json:"challenges,omitempty"`
+	Failure    *AuthFailure    `json:"failure,omitempty"`
+	Upstream   *AuthUpstream   `json:"upstream,omitempty"`
+}
+
+type AuthChallenge struct {
+	Instruction string               `json:"instruction"`
+	Fields      []AuthChallengeField `json:"fields"`
+}
+
+type AuthChallengeField struct {
+	Key    string `json:"key"`
+	Prompt string `json:"prompt"`
+	Secret bool   `json:"secret"`
+}
+
+type AuthFailure struct {
+	Message    string `json:"message"`
+	Reason     uint32 `json:"reason,omitempty"`
+	Disconnect bool   `json:"disconnect,omitempty"`
+}
+
+type AuthUpstream struct {
+	Host          string  `json:"host"`
+	PrivateKey    string  `json:"private_key,omitempty"`
+	Certificate   string  `json:"certificate,omitempty"`
+	Password      *string `json:"password,omitempty"`
+	ProxyProtocol byte    `json:"proxy_protocol,omitempty"`
+}
+
+type Authenticator interface {
+	Auth(request AuthRequest, username string) (int, *AuthResponse, error)
 }
 
 func removePublicKeyMethod(methods []string) []string {

--- a/auth.go
+++ b/auth.go
@@ -1,41 +1,6 @@
 package main
 
-import (
-	"bytes"
-	"encoding/base64"
-	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
-	"slices"
-
-	"golang.org/x/crypto/ssh"
-)
-
-type AuthRequestPublicKey struct {
-	AuthType      string `json:"auth_type"`
-	UnixUsername  string `json:"unix_username"`
-	PublicKeyType string `json:"public_key_type"`
-	PublicKeyData string `json:"public_key_data"`
-	Token         string `json:"token"`
-}
-
-type AuthRequestPassword struct {
-	AuthType     string `json:"auth_type"`
-	Username     string `json:"username"`
-	Password     string `json:"password"`
-	UnixUsername string `json:"unix_username"`
-	Token        string `json:"token"`
-}
-
-type AuthResponse struct {
-	Status        string `json:"status"`
-	Address       string `json:"address"`
-	PrivateKey    string `json:"private_key"`
-	Cert          string `json:"cert"`
-	Id            int    `json:"vmid"`
-	ProxyProtocol byte   `json:"proxy_protocol,omitempty"`
-}
+import "golang.org/x/crypto/ssh"
 
 type UpstreamInformation struct {
 	Host          string
@@ -44,18 +9,14 @@ type UpstreamInformation struct {
 	ProxyProtocol byte
 }
 
-type Authenticator struct {
-	Endpoint string
-	Token    string
-	Recovery RecoveryConfig
-}
-
-func makeAuthenticator(auth AuthConfig, recovery RecoveryConfig) Authenticator {
-	return Authenticator{
-		Endpoint: auth.Endpoint,
-		Token:    auth.Token,
-		Recovery: recovery,
+func removePublicKeyMethod(methods []string) []string {
+	res := make([]string, 0, len(methods))
+	for _, s := range methods {
+		if s != "publickey" {
+			res = append(res, s)
+		}
 	}
+	return res
 }
 
 func parsePrivateKey(key string, cert string) ssh.Signer {
@@ -78,75 +39,4 @@ func parsePrivateKey(key string, cert string) ssh.Signer {
 		return signer
 	}
 	return certSigner
-}
-
-func (auth Authenticator) AuthUser(request any, username string) (*UpstreamInformation, error) {
-	payload := new(bytes.Buffer)
-	if err := json.NewEncoder(payload).Encode(request); err != nil {
-		return nil, err
-	}
-	res, err := http.Post(auth.Endpoint, "application/json", payload)
-	if err != nil {
-		return nil, err
-	}
-	defer res.Body.Close()
-	body, err := io.ReadAll(res.Body)
-	if err != nil {
-		return nil, err
-	}
-	var response AuthResponse
-	err = json.Unmarshal(body, &response)
-	if err != nil {
-		return nil, err
-	}
-	if response.Status != "ok" {
-		return nil, nil
-	}
-
-	var upstream UpstreamInformation
-	// FIXME: Can this be handled in API server?
-	if slices.Contains(auth.Recovery.Usernames, username) {
-		upstream.Host = auth.Recovery.Address
-		password := fmt.Sprintf("%d %s", response.Id, auth.Recovery.Token)
-		upstream.Password = &password
-	} else {
-		upstream.Host = response.Address
-	}
-	upstream.Signer = parsePrivateKey(response.PrivateKey, response.Cert)
-	upstream.ProxyProtocol = response.ProxyProtocol
-	return &upstream, nil
-}
-
-func (auth Authenticator) AuthUserWithPublicKey(key ssh.PublicKey, unixUsername string) (*UpstreamInformation, error) {
-	keyType := key.Type()
-	keyData := base64.StdEncoding.EncodeToString(key.Marshal())
-	request := &AuthRequestPublicKey{
-		AuthType:      "key",
-		UnixUsername:  unixUsername,
-		PublicKeyType: keyType,
-		PublicKeyData: keyData,
-		Token:         auth.Token,
-	}
-	return auth.AuthUser(request, unixUsername)
-}
-
-func (auth Authenticator) AuthUserWithUserPass(username string, password string, unixUsername string) (*UpstreamInformation, error) {
-	request := &AuthRequestPassword{
-		AuthType:     "key",
-		Username:     username,
-		Password:     password,
-		UnixUsername: unixUsername,
-		Token:        auth.Token,
-	}
-	return auth.AuthUser(request, unixUsername)
-}
-
-func removePublicKeyMethod(methods []string) []string {
-	res := make([]string, 0, len(methods))
-	for _, s := range methods {
-		if s != "publickey" {
-			res = append(res, s)
-		}
-	}
-	return res
 }

--- a/auth.go
+++ b/auth.go
@@ -21,6 +21,7 @@ type AuthResponse struct {
 	Challenges []AuthChallenge `json:"challenges,omitempty"`
 	Failure    *AuthFailure    `json:"failure,omitempty"`
 	Upstream   *AuthUpstream   `json:"upstream,omitempty"`
+	Proxy      *AuthProxy      `json:"proxy,omitempty"`
 }
 
 type AuthChallenge struct {
@@ -41,12 +42,17 @@ type AuthFailure struct {
 }
 
 type AuthUpstream struct {
-	Host          string  `json:"host"`
-	Port          uint16  `json:"port,omitempty"`
-	PrivateKey    string  `json:"private_key,omitempty"`
-	Certificate   string  `json:"certificate,omitempty"`
-	Password      *string `json:"password,omitempty"`
-	ProxyProtocol *string `json:"proxy_protocol,omitempty"`
+	Host        string  `json:"host"`
+	Port        uint16  `json:"port,omitempty"`
+	PrivateKey  string  `json:"private_key,omitempty"`
+	Certificate string  `json:"certificate,omitempty"`
+	Password    *string `json:"password,omitempty"`
+}
+
+type AuthProxy struct {
+	Host     string  `json:"host,omitempty"`
+	Port     uint16  `json:"port,omitempty"`
+	Protocol *string `json:"protocol,omitempty"`
 }
 
 type Authenticator interface {

--- a/auth.go
+++ b/auth.go
@@ -100,7 +100,9 @@ func (auth *RESTfulAuthenticator) Auth(request AuthRequest, username string) (in
 	if err != nil {
 		return 0, nil, err
 	}
-	req.Header = auth.Headers
+	req.Header = auth.Headers.Clone()
+	req.Header.Set("accept", "application/json")
+	req.Header.Set("content-type", "application/json")
 
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/auth.go
+++ b/auth.go
@@ -46,7 +46,7 @@ type AuthUpstream struct {
 	PrivateKey    string  `json:"private_key,omitempty"`
 	Certificate   string  `json:"certificate,omitempty"`
 	Password      *string `json:"password,omitempty"`
-	ProxyProtocol byte    `json:"proxy_protocol,omitempty"`
+	ProxyProtocol *string `json:"proxy_protocol,omitempty"`
 }
 
 type Authenticator interface {

--- a/auth.go
+++ b/auth.go
@@ -52,6 +52,16 @@ type Authenticator interface {
 	Auth(request AuthRequest, username string) (int, *AuthResponse, error)
 }
 
+func makeAuthenticator(auth AuthConfig) Authenticator {
+	if auth.Version == "" {
+		auth.Version = "v1"
+	}
+	return &RESTfulAuthenticator{
+		Endpoint: auth.Endpoint,
+		Version:  auth.Version,
+	}
+}
+
 type RESTfulAuthenticator struct {
 	Endpoint string
 	Version  string

--- a/config.go
+++ b/config.go
@@ -18,8 +18,9 @@ type SSHKeyConfig struct {
 
 type AuthConfig struct {
 	Endpoint string `toml:"endpoint"`
-	Token    string `toml:"token"`
-	// The following should be moved into API server
+	Version  string `toml:"version,omitempty"`
+	// The following settings are for legacy API only
+	Token                  string   `toml:"token,omitempty"`
 	InvalidUsernames       []string `toml:"invalid-usernames,omitempty"`
 	InvalidUsernameMessage string   `toml:"invalid-username-message,omitempty"`
 	AllUsernameNoPassword  bool     `toml:"all-username-nopassword,omitempty"`
@@ -38,9 +39,9 @@ type ProxyProtocolConfig struct {
 }
 
 type RecoveryConfig struct {
-	Address   string   `toml:"address"`
-	Usernames []string `toml:"usernames"`
-	Token     string   `toml:"token"`
+	Address   string   `toml:"address,omitempty"`
+	Usernames []string `toml:"usernames,omitempty"`
+	Token     string   `toml:"token,omitempty"`
 }
 
 type Config struct {
@@ -101,6 +102,7 @@ func convertLegacyConfig(config LegacyConfig) Config {
 		},
 		Auth: AuthConfig{
 			Endpoint:               config.API,
+			Version:                "legacy",
 			Token:                  config.Token,
 			InvalidUsernames:       config.InvalidUsername,
 			InvalidUsernameMessage: config.InvalidUsernameMessage,

--- a/config.go
+++ b/config.go
@@ -17,14 +17,20 @@ type SSHKeyConfig struct {
 }
 
 type AuthConfig struct {
-	Endpoint string `toml:"endpoint"`
-	Version  string `toml:"version,omitempty"`
+	Endpoint string                 `toml:"endpoint"`
+	Version  string                 `toml:"version,omitempty"`
+	Headers  []AuthHTTPHeaderConfig `toml:"headers,omitempty"`
 	// The following settings are for legacy API only
 	Token                  string   `toml:"token,omitempty"`
 	InvalidUsernames       []string `toml:"invalid-usernames,omitempty"`
 	InvalidUsernameMessage string   `toml:"invalid-username-message,omitempty"`
 	AllUsernameNoPassword  bool     `toml:"all-username-nopassword,omitempty"`
 	UsernamesNoPassword    []string `toml:"usernames-nopassword,omitempty"`
+}
+
+type AuthHTTPHeaderConfig struct {
+	Name  string `toml:"name"`
+	Value string `toml:"value"`
 }
 
 type LoggerConfig struct {

--- a/etc/config.example.toml
+++ b/etc/config.example.toml
@@ -10,8 +10,9 @@ host-keys = [
 
 [auth]
 endpoint = "http://127.0.0.1:5000/ssh"
-token = "token"
+version = "legacy"
 # Legacy settings
+token = "token"
 all-username-nopassword = true
 usernames-nopassword = ["vlab", "ubuntu", "root"]
 invalid-usernames = ["用户名"]

--- a/fixtures/config.toml
+++ b/fixtures/config.toml
@@ -20,8 +20,9 @@ path = "fixtures/ssh_host_rsa_key"
 
 [auth]
 endpoint = "http://127.0.0.1:5000/ssh"
-token = "token"
+version = "legacy"
 # Legacy settings
+token = "token"
 all-username-nopassword = true
 usernames-nopassword = ["vlab", "ubuntu", "root"]
 invalid-usernames = ["用户名"]

--- a/fixtures/config.toml
+++ b/fixtures/config.toml
@@ -21,6 +21,9 @@ path = "fixtures/ssh_host_rsa_key"
 [auth]
 endpoint = "http://127.0.0.1:5000"
 version = "v1"
+headers = [
+    { name = "Authorization", value = "ApiKey 12345678" },
+]
 
 [logger]
 enabled = false

--- a/fixtures/legacy.toml
+++ b/fixtures/legacy.toml
@@ -19,11 +19,18 @@ base64 = "LS0tLS1CRUdJTiBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0KYjNCbGJuTnphQzFyWlhrdG
 path = "fixtures/ssh_host_rsa_key"
 
 [auth]
-endpoint = "http://127.0.0.1:5000"
-version = "v1"
+endpoint = "http://127.0.0.1:5000/ssh"
+version = "legacy"
+# Legacy settings
+token = "token"
+all-username-nopassword = true
+usernames-nopassword = ["vlab", "ubuntu", "root"]
+invalid-usernames = ["用户名"]
+invalid-username-message = "Invalid username %s. Please check https://vlab.ustc.edu.cn/docs/login/ssh/#username for more information."
 
 [logger]
-enabled = false
+enabled = true
+endpoint = "udp://127.0.0.1:5556"
 
 [proxy-protocol]
 enabled = true

--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,8 @@ require github.com/pires/go-proxyproto v0.7.0
 
 require github.com/pelletier/go-toml/v2 v2.2.2
 
-require (
-	golang.org/x/sys v0.21.0 // indirect
-)
+require github.com/julienschmidt/httprouter v1.3.0
+
+require golang.org/x/sys v0.21.0 // indirect
 
 replace golang.org/x/crypto => ./crypto

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/libp2p/go-reuseport v0.4.0 h1:nR5KU7hD0WxXCJbmw7r2rhRYruNRl2koHw8fQscQm2s=
 github.com/libp2p/go-reuseport v0.4.0/go.mod h1:ZtI03j/wO5hZVDFo2jKywN6bYKWLOy8Se6DrI2E1cLU=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=

--- a/legacy_auth.go
+++ b/legacy_auth.go
@@ -128,16 +128,19 @@ func (auth *LegacyAuthenticator) Auth(request AuthRequest, username string) (int
 			return 500, nil, err
 		}
 		auth_upstream := AuthUpstream{
-			Host:          address.Addr().String(),
-			Port:          address.Port(),
-			PrivateKey:    upstream.PrivateKey,
-			Certificate:   upstream.Certificate,
-			Password:      upstream.Password,
-			ProxyProtocol: upstream.ProxyProtocol,
+			Host:        address.Addr().String(),
+			Port:        address.Port(),
+			PrivateKey:  upstream.PrivateKey,
+			Certificate: upstream.Certificate,
+			Password:    upstream.Password,
 		}
 		unix_password, has_unix_password := request.Payload["unix_password"]
 		if has_unix_password {
 			auth_upstream.Password = &unix_password
+		}
+		if upstream.ProxyProtocol > 0 {
+			proxyProtocol := fmt.Sprintf("v%d", upstream.ProxyProtocol)
+			auth_upstream.ProxyProtocol = &proxyProtocol
 		}
 		resp := AuthResponse{Upstream: &auth_upstream}
 		return 200, &resp, nil

--- a/legacy_auth.go
+++ b/legacy_auth.go
@@ -127,22 +127,23 @@ func (auth *LegacyAuthenticator) Auth(request AuthRequest, username string) (int
 		if err != nil {
 			return 500, nil, err
 		}
-		auth_upstream := AuthUpstream{
-			Host:        address.Addr().String(),
-			Port:        address.Port(),
-			PrivateKey:  upstream.PrivateKey,
-			Certificate: upstream.Certificate,
-			Password:    upstream.Password,
+		resp := AuthResponse{
+			Upstream: &AuthUpstream{
+				Host:        address.Addr().String(),
+				Port:        address.Port(),
+				PrivateKey:  upstream.PrivateKey,
+				Certificate: upstream.Certificate,
+				Password:    upstream.Password,
+			},
 		}
 		unix_password, has_unix_password := request.Payload["unix_password"]
 		if has_unix_password {
-			auth_upstream.Password = &unix_password
+			resp.Upstream.Password = &unix_password
 		}
 		if upstream.ProxyProtocol > 0 {
-			proxyProtocol := fmt.Sprintf("v%d", upstream.ProxyProtocol)
-			auth_upstream.ProxyProtocol = &proxyProtocol
+			protocolVersion := fmt.Sprintf("v%d", upstream.ProxyProtocol)
+			resp.Proxy = &AuthProxy{Protocol: &protocolVersion}
 		}
-		resp := AuthResponse{Upstream: &auth_upstream}
 		return 200, &resp, nil
 	}
 	return 403, &AuthResponse{}, nil

--- a/legacy_auth.go
+++ b/legacy_auth.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/netip"
 	"slices"
 
 	"golang.org/x/crypto/ssh"
@@ -122,8 +123,13 @@ func (auth *LegacyAuthenticator) Auth(request AuthRequest, username string) (int
 		}
 	}
 	if upstream != nil {
+		address, err := netip.ParseAddrPort(upstream.Host)
+		if err != nil {
+			return 500, nil, err
+		}
 		auth_upstream := AuthUpstream{
-			Host:          upstream.Host,
+			Host:          address.Addr().String(),
+			Port:          address.Port(),
 			PrivateKey:    upstream.PrivateKey,
 			Certificate:   upstream.Certificate,
 			Password:      upstream.Password,

--- a/legacy_auth.go
+++ b/legacy_auth.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+
+	"golang.org/x/crypto/ssh"
+)
+
+type LegacyAuthRequestPublicKey struct {
+	AuthType      string `json:"auth_type"`
+	UnixUsername  string `json:"unix_username"`
+	PublicKeyType string `json:"public_key_type"`
+	PublicKeyData string `json:"public_key_data"`
+	Token         string `json:"token"`
+}
+
+type LegacyAuthRequestPassword struct {
+	AuthType     string `json:"auth_type"`
+	Username     string `json:"username"`
+	Password     string `json:"password"`
+	UnixUsername string `json:"unix_username"`
+	Token        string `json:"token"`
+}
+
+type LegacyAuthResponse struct {
+	Status        string `json:"status"`
+	Address       string `json:"address"`
+	PrivateKey    string `json:"private_key"`
+	Cert          string `json:"cert"`
+	Id            int    `json:"vmid"`
+	ProxyProtocol byte   `json:"proxy_protocol,omitempty"`
+}
+
+type LegacyAuthenticator struct {
+	Endpoint string
+	Token    string
+	Recovery RecoveryConfig
+}
+
+func makeLegacyAuthenticator(auth AuthConfig, recovery RecoveryConfig) LegacyAuthenticator {
+	return LegacyAuthenticator{
+		Endpoint: auth.Endpoint,
+		Token:    auth.Token,
+		Recovery: recovery,
+	}
+}
+
+func (auth LegacyAuthenticator) AuthUser(request any, username string) (*UpstreamInformation, error) {
+	payload := new(bytes.Buffer)
+	if err := json.NewEncoder(payload).Encode(request); err != nil {
+		return nil, err
+	}
+	res, err := http.Post(auth.Endpoint, "application/json", payload)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	var response LegacyAuthResponse
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return nil, err
+	}
+	if response.Status != "ok" {
+		return nil, nil
+	}
+
+	var upstream UpstreamInformation
+	// FIXME: Can this be handled in API server?
+	if slices.Contains(auth.Recovery.Usernames, username) {
+		upstream.Host = auth.Recovery.Address
+		password := fmt.Sprintf("%d %s", response.Id, auth.Recovery.Token)
+		upstream.Password = &password
+	} else {
+		upstream.Host = response.Address
+	}
+	upstream.Signer = parsePrivateKey(response.PrivateKey, response.Cert)
+	upstream.ProxyProtocol = response.ProxyProtocol
+	return &upstream, nil
+}
+
+func (auth LegacyAuthenticator) AuthUserWithPublicKey(key ssh.PublicKey, unixUsername string) (*UpstreamInformation, error) {
+	keyType := key.Type()
+	keyData := base64.StdEncoding.EncodeToString(key.Marshal())
+	request := &LegacyAuthRequestPublicKey{
+		AuthType:      "key",
+		UnixUsername:  unixUsername,
+		PublicKeyType: keyType,
+		PublicKeyData: keyData,
+		Token:         auth.Token,
+	}
+	return auth.AuthUser(request, unixUsername)
+}
+
+func (auth LegacyAuthenticator) AuthUserWithUserPass(username string, password string, unixUsername string) (*UpstreamInformation, error) {
+	request := &LegacyAuthRequestPassword{
+		AuthType:     "key",
+		Username:     username,
+		Password:     password,
+		UnixUsername: unixUsername,
+		Token:        auth.Token,
+	}
+	return auth.AuthUser(request, unixUsername)
+}

--- a/sshmux.go
+++ b/sshmux.go
@@ -190,7 +190,7 @@ func (s *Server) Handshake(session *ssh.PipeSession) error {
 			return err
 		}
 	}
-	// Stage 1: Get publickey or keyboard-interactive answers, and authenticate the user with with API
+	// Stage 1: Authenticate the user with API
 auth_requests:
 	for {
 		authReq, err := session.Downstream.ReadAuthRequest(true)
@@ -251,7 +251,7 @@ auth_requests:
 			case 401:
 				if len(resp.Challenges) == 0 {
 					// The API server is requesting no challenges, which is abnormal and will
-					// likely lead to an infinite loop. Silently fail in such case.
+					// likely lead to an infinite loop
 					session.Downstream.WriteAuthFailure([]string{"publickey", "keyboard-interactive"}, false)
 					continue auth_requests
 				}
@@ -338,7 +338,7 @@ auth_requests:
 	if err != nil {
 		return err
 	}
-	// For the first auth fail, we mark it partial succss
+	// For the first auth fail, we mark it as partial success
 	if !res.Success {
 		err = session.Downstream.WriteAuthFailure(removePublicKeyMethod(res.Methods), true)
 	} else {
@@ -350,7 +350,7 @@ auth_requests:
 	if res.Success {
 		return nil
 	}
-	// Finally, pipe downstream and upstream's auth request and result
+	// Finally, pipe downstream and upstream's auth requests and results
 	// Note that publickey auth cannot be used anymore after this point
 	for {
 		req, err := session.Downstream.ReadAuthRequest(true)

--- a/sshmux.go
+++ b/sshmux.go
@@ -92,11 +92,11 @@ func makeServer(config Config) (*Server, error) {
 		if loggerURL.Scheme == "udp" {
 			conn, err := net.Dial("udp", loggerURL.Host)
 			if err != nil {
-				log.Fatalf("Logger Dial failed: %s\n", err)
+				return nil, fmt.Errorf("logger dial failed: %s", err)
 			}
 			logWriter = conn
 		} else {
-			log.Fatalf("unsupported logger endpoint: %s\n", config.Logger.Endpoint)
+			return nil, fmt.Errorf("unsupported logger endpoint: %s", config.Logger.Endpoint)
 		}
 	} else {
 		logWriter = io.Discard

--- a/sshmux.go
+++ b/sshmux.go
@@ -93,7 +93,7 @@ func makeServer(config Config) (*Server, error) {
 		if loggerURL.Scheme == "udp" {
 			conn, err := net.Dial("udp", loggerURL.Host)
 			if err != nil {
-				return nil, fmt.Errorf("logger dial failed: %s", err)
+				return nil, fmt.Errorf("logger dial failed: %w", err)
 			}
 			logWriter = conn
 		} else {

--- a/sshmux.go
+++ b/sshmux.go
@@ -106,7 +106,11 @@ func makeServer(config Config) (*Server, error) {
 		legacyAuthenticator := makeLegacyAuthenticator(config.Auth, config.Recovery)
 		authenticator = &legacyAuthenticator
 	} else {
-		authenticator = makeAuthenticator(config.Auth)
+		var err error
+		authenticator, err = makeAuthenticator(config.Auth)
+		if err != nil {
+			return nil, err
+		}
 	}
 	sshmux := &Server{
 		Address:       config.Address,

--- a/sshmux.go
+++ b/sshmux.go
@@ -219,10 +219,19 @@ auth_requests:
 					upstreamResp.Port = 22
 				}
 				upstream = &UpstreamInformation{
-					Host:          netip.AddrPortFrom(host, upstreamResp.Port).String(),
-					Signer:        parsePrivateKey(upstreamResp.PrivateKey, upstreamResp.Certificate),
-					Password:      upstreamResp.Password,
-					ProxyProtocol: upstreamResp.ProxyProtocol,
+					Host:     netip.AddrPortFrom(host, upstreamResp.Port).String(),
+					Signer:   parsePrivateKey(upstreamResp.PrivateKey, upstreamResp.Certificate),
+					Password: upstreamResp.Password,
+				}
+				if upstreamResp.ProxyProtocol != nil {
+					switch *upstreamResp.ProxyProtocol {
+					case "v1":
+						upstream.ProxyProtocol = 1
+					case "v2":
+						upstream.ProxyProtocol = 2
+					default:
+						return fmt.Errorf("unknown PROXY protocol version: %s", *upstreamResp.ProxyProtocol)
+					}
 				}
 				break auth_requests
 			case 401:

--- a/sshmux.go
+++ b/sshmux.go
@@ -201,8 +201,15 @@ auth_requests:
 			switch status {
 			case 200:
 				upstreamResp := *resp.Upstream
+				host, err := netip.ParseAddr(upstreamResp.Host)
+				if err != nil {
+					return err
+				}
+				if upstreamResp.Port == 0 {
+					upstreamResp.Port = 22
+				}
 				upstream = &UpstreamInformation{
-					Host:          upstreamResp.Host,
+					Host:          netip.AddrPortFrom(host, upstreamResp.Port).String(),
 					Signer:        parsePrivateKey(upstreamResp.PrivateKey, upstreamResp.Certificate),
 					Password:      upstreamResp.Password,
 					ProxyProtocol: upstreamResp.ProxyProtocol,

--- a/sshmux.go
+++ b/sshmux.go
@@ -101,12 +101,18 @@ func makeServer(config Config) (*Server, error) {
 	} else {
 		logWriter = io.Discard
 	}
-	authenticator := makeLegacyAuthenticator(config.Auth, config.Recovery)
+	var authenticator Authenticator
+	if config.Auth.Version == "" || config.Auth.Version == "legacy" {
+		legacyAuthenticator := makeLegacyAuthenticator(config.Auth, config.Recovery)
+		authenticator = &legacyAuthenticator
+	} else {
+		authenticator = makeAuthenticator(config.Auth)
+	}
 	sshmux := &Server{
 		Address:       config.Address,
 		Banner:        config.SSH.Banner,
 		SSHConfig:     sshConfig,
-		Authenticator: &authenticator,
+		Authenticator: authenticator,
 		LogWriter:     logWriter,
 		ProxyPolicy:   proxyPolicyConfig,
 	}

--- a/sshmux.go
+++ b/sshmux.go
@@ -247,6 +247,12 @@ auth_requests:
 				}
 				break auth_requests
 			case 401:
+				if len(resp.Challenges) == 0 {
+					// The API server is requesting no challenges, which is abnormal and will
+					// likely lead to an infinite loop. Silently fail in such case.
+					session.Downstream.WriteAuthFailure([]string{"publickey", "keyboard-interactive"}, false)
+					continue auth_requests
+				}
 				for _, challenge := range resp.Challenges {
 					questions := make([]string, 0, len(challenge.Fields))
 					withEcho := make([]bool, 0, len(challenge.Fields))

--- a/sshmux.go
+++ b/sshmux.go
@@ -28,7 +28,7 @@ type Server struct {
 	Address        string
 	Banner         string
 	SSHConfig      *ssh.ServerConfig
-	Authenticator  Authenticator
+	Authenticator  LegacyAuthenticator
 	LogWriter      io.Writer
 	ProxyPolicy    ProxyPolicyConfig
 	UsernamePolicy UsernamePolicyConfig
@@ -101,7 +101,7 @@ func makeServer(config Config) (*Server, error) {
 		Address:       config.Address,
 		Banner:        config.SSH.Banner,
 		SSHConfig:     sshConfig,
-		Authenticator: makeAuthenticator(config.Auth, config.Recovery),
+		Authenticator: makeLegacyAuthenticator(config.Auth, config.Recovery),
 		LogWriter:     logWriter,
 		ProxyPolicy:   proxyPolicyConfig,
 		UsernamePolicy: UsernamePolicyConfig{

--- a/sshmux_test.go
+++ b/sshmux_test.go
@@ -82,9 +82,10 @@ func initHttp(sshPrivateKey []byte) {
 			PrivateKey: string(sshPrivateKey),
 		}
 		if enableProxy {
+			proxyProtocol := "v2"
 			upstream.Host = sshdProxiedAddr.IP.String()
 			upstream.Port = uint16(sshdProxiedAddr.Port)
-			upstream.ProxyProtocol = 2
+			upstream.ProxyProtocol = &proxyProtocol
 		} else {
 			upstream.Host = sshdServerAddr.IP.String()
 			upstream.Port = uint16(sshdServerAddr.Port)

--- a/sshmux_test.go
+++ b/sshmux_test.go
@@ -45,16 +45,16 @@ func initHttp(sshPrivateKey []byte) {
 			return
 		}
 
-		res := &LegacyAuthResponse{
-			Status:     "ok",
-			Id:         1141919,
-			PrivateKey: string(sshPrivateKey),
+		res := map[string]any{
+			"status":      "ok",
+			"vmid":        1141919,
+			"private_key": string(sshPrivateKey),
 		}
 		if enableProxy {
-			res.Address = sshdProxiedAddr.String()
-			res.ProxyProtocol = 2
+			res["address"] = sshdProxiedAddr.String()
+			res["proxy_protocol"] = 2
 		} else {
-			res.Address = sshdServerAddr.String()
+			res["address"] = sshdServerAddr.String()
 		}
 
 		jsonRes, err := json.Marshal(res)
@@ -78,20 +78,18 @@ func initHttp(sshPrivateKey []byte) {
 			return
 		}
 
-		upstream := AuthUpstream{
-			PrivateKey: string(sshPrivateKey),
-		}
+		upstream := map[string]any{"private_key": string(sshPrivateKey)}
 		if enableProxy {
-			proxyProtocol := "v2"
-			upstream.Host = sshdProxiedAddr.IP.String()
-			upstream.Port = uint16(sshdProxiedAddr.Port)
-			upstream.ProxyProtocol = &proxyProtocol
+			upstream["host"] = sshdProxiedAddr.IP.String()
+			upstream["port"] = sshdProxiedAddr.Port
+			upstream["proxy_protocol"] = "v2"
 		} else {
-			upstream.Host = sshdServerAddr.IP.String()
-			upstream.Port = uint16(sshdServerAddr.Port)
+			upstream["host"] = sshdServerAddr.IP.String()
+			upstream["port"] = sshdServerAddr.Port
 		}
 
-		jsonRes, err := json.Marshal(AuthResponse{Upstream: &upstream})
+		res := map[string]any{"upstream": upstream}
+		jsonRes, err := json.Marshal(res)
 		if err != nil {
 			http.Error(w, "Cannot encode JSON", http.StatusInternalServerError)
 			return

--- a/sshmux_test.go
+++ b/sshmux_test.go
@@ -78,17 +78,20 @@ func initHttp(sshPrivateKey []byte) {
 			return
 		}
 
-		upstream := map[string]any{"private_key": string(sshPrivateKey)}
+		res := map[string]any{
+			"upstream": map[string]any{
+				"host":        sshdServerAddr.IP.String(),
+				"port":        sshdServerAddr.Port,
+				"private_key": string(sshPrivateKey),
+			},
+		}
 		if enableProxy {
-			upstream["host"] = sshdProxiedAddr.IP.String()
-			upstream["port"] = sshdProxiedAddr.Port
-			upstream["proxy_protocol"] = "v2"
-		} else {
-			upstream["host"] = sshdServerAddr.IP.String()
-			upstream["port"] = sshdServerAddr.Port
+			res["proxy"] = map[string]any{
+				"host": sshdProxiedAddr.IP.String(),
+				"port": sshdProxiedAddr.Port,
+			}
 		}
 
-		res := map[string]any{"upstream": upstream}
 		jsonRes, err := json.Marshal(res)
 		if err != nil {
 			http.Error(w, "Cannot encode JSON", http.StatusInternalServerError)

--- a/sshmux_test.go
+++ b/sshmux_test.go
@@ -44,7 +44,7 @@ func initHttp(sshPrivateKey []byte) {
 			return
 		}
 
-		res := &AuthResponse{
+		res := &LegacyAuthResponse{
 			Status:     "ok",
 			Id:         1141919,
 			PrivateKey: string(sshPrivateKey),


### PR DESCRIPTION
This PR adds a new RESTful API for authentication and authorization. It is meant to be stateless and allows for customizing multi-round challenges for required information. It provides a path for `sshmux` to be a completely generic MitM without wiring Vlab system logic.

Closes https://github.com/USTC-vlab/sshmux/issues/6