### PR TITLE
Fix passing addresses with PROXY protocol

### DIFF
--- a/sshmux.go
+++ b/sshmux.go
@@ -257,7 +257,7 @@ func (s *Server) Handshake(session *ssh.PipeSession) error {
 		return err
 	}
 	if upstream.ProxyProtocol > 0 {
-		header := proxyproto.HeaderProxyFromAddrs(upstream.ProxyProtocol, session.Downstream.RemoteAddr(), nil)
+		header := proxyproto.HeaderProxyFromAddrs(upstream.ProxyProtocol, session.Downstream.RemoteAddr(), conn.RemoteAddr())
 		_, err := header.WriteTo(conn)
 		if err != nil {
 			return err

--- a/sshmux_test.go
+++ b/sshmux_test.go
@@ -94,7 +94,7 @@ func initUpstreamProxyServer() {
 				log.Fatal(err)
 			}
 			// 2. Send PROXY header to sshmux
-			header := proxyproto.HeaderProxyFromAddrs(2, conn.RemoteAddr(), nil)
+			header := proxyproto.HeaderProxyFromAddrs(2, conn.RemoteAddr(), sshmux.RemoteAddr())
 			_, err = header.WriteTo(sshmux)
 			if err != nil {
 				log.Fatal(err)


### PR DESCRIPTION
`go-proxyproto` requires both addresses to be specified, so here's the fix to make it actually function.