### PR TITLE
Expose basic client info to the auth API

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ PROXY protocol settings configures [PROXY protocol](https://www.haproxy.com/blog
 | Key               | Type                  | Description                                                                                    | Position | Required |
 | ----------------- | --------------------- | ---------------------------------------------------------------------------------------------- | -------- | -------- |
 | `username`        | `string`              | SSH user name. Usually the one for logging into the target server.                             | Path     | Yes      |
+| `client_address`  | `string`              | Address of the SSH client as `host:port`. Reflects the original client under PROXY protocol.   | Body     | Yes      |
+| `client_version`  | `string`              | SSH client identification string, e.g. `"SSH-2.0-OpenSSH_9.9"`.                                | Body     | Yes      |
+| `session_id`      | `string`              | Base64-encoded SSH session ID, unique per connection and stable across its auth requests.      | Body     | Yes      |
 | `method`          | `string`              | SSH authentication method. Usually one of `"none"`, `"publickey"` or `"keyboard-interactive"`. | Body     | Yes      |
 | `public_key`      | `string`              | User public key, serialized in OpenSSH format.                                                 | Body     | No       |
 | `payload`         | `Map<string, string>` | Authentication payload constructed from interactive input.                                     | Body     | No       |

--- a/auth.go
+++ b/auth.go
@@ -13,9 +13,12 @@ import (
 )
 
 type AuthRequest struct {
-	Method    string            `json:"method"`
-	PublicKey string            `json:"public_key,omitempty"`
-	Payload   map[string]string `json:"payload"`
+	ClientAddress string            `json:"client_address"`
+	ClientVersion string            `json:"client_version"`
+	SessionID     string            `json:"session_id"`
+	Method        string            `json:"method"`
+	PublicKey     string            `json:"public_key,omitempty"`
+	Payload       map[string]string `json:"payload"`
 }
 
 type AuthResponse struct {

--- a/sshmux.go
+++ b/sshmux.go
@@ -205,6 +205,10 @@ func (s *Server) Handshake(session *ssh.PipeSession) error {
 			return err
 		}
 	}
+	// Basic information about the downstream client, constant for the connection
+	clientAddress := session.Downstream.RemoteAddr().String()
+	clientVersion := string(session.Downstream.ClientVersion())
+	sessionID := base64.StdEncoding.EncodeToString(session.Downstream.SessionID())
 	// Stage 1: Authenticate the user with API
 auth_requests:
 	for {
@@ -217,7 +221,12 @@ auth_requests:
 			session.Downstream.SetUser(user)
 			hasSetUser = true
 		}
-		req := AuthRequest{Method: authReq.Method}
+		req := AuthRequest{
+			ClientAddress: clientAddress,
+			ClientVersion: clientVersion,
+			SessionID:     sessionID,
+			Method:        authReq.Method,
+		}
 		if authReq.Method == "publickey" && !authReq.IsPublicKeyQuery {
 			req.PublicKey = string(ssh.MarshalAuthorizedKey(*authReq.PublicKey))
 		}

--- a/sshmux_test.go
+++ b/sshmux_test.go
@@ -36,6 +36,27 @@ func localhostTCPAddr(port int) *net.TCPAddr {
 var enableProxy bool
 var inited bool
 
+// checkClientInfo validates the client information sshmux reports on an auth
+// request, and describes the first problem found, if any.
+func checkClientInfo(request AuthRequest) string {
+	host, port, err := net.SplitHostPort(request.ClientAddress)
+	if err != nil {
+		return fmt.Sprintf("malformed client address %q", request.ClientAddress)
+	}
+	// every test client connects from localhost, including the ones whose
+	// address only survives in the PROXY header
+	if host != "127.0.0.1" || port == "0" {
+		return fmt.Sprintf("unexpected client address %q", request.ClientAddress)
+	}
+	if !strings.HasPrefix(request.ClientVersion, "SSH-2.0-") {
+		return fmt.Sprintf("unexpected client version %q", request.ClientVersion)
+	}
+	if request.SessionID == "" {
+		return "missing session ID"
+	}
+	return ""
+}
+
 func initHttp(sshPrivateKey []byte) {
 	sshAPIHandler := func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		body, err := io.ReadAll(r.Body)
@@ -76,9 +97,24 @@ func initHttp(sshPrivateKey []byte) {
 			http.Error(w, "Cannot read body", http.StatusBadRequest)
 			return
 		}
-		var dat map[string]interface{}
-		if err := json.Unmarshal(body, &dat); err != nil {
-			http.Error(w, "Not JSON", http.StatusBadRequest)
+		var req AuthRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			http.Error(w, "Not an auth request", http.StatusBadRequest)
+			return
+		}
+		if problem := checkClientInfo(req); problem != "" {
+			// the message reaches the SSH client, but log it as well to explain
+			// the connection failure the test will report
+			log.Printf("auth API: %s", problem)
+			failure := AuthFailure{Message: problem, Disconnect: true}
+			jsonRes, err := json.Marshal(AuthResponse{Failure: &failure})
+			if err != nil {
+				http.Error(w, "Cannot encode JSON", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			w.Write(jsonRes)
 			return
 		}
 


### PR DESCRIPTION
The v1 auth API request now carries `client_address`, `client_version` and `session_id`, so the auth server can apply per-client policies and audit logins. All three are always present.

`client_address` is taken from the downstream connection, which reflects the original client when the connection arrives through PROXY protocol. `session_id` is stable across all auth requests of one connection.

**Impact:** 3 additional fields on each auth requests, the auth API server must tolerate extra fields, or the change would be breaking. If that is a concern, this feature can be gated behind an `auth` config item.

---

**Disclaimer:** This PR is mostly drafted by [Claude Code](https://claude.com/claude-code) under human instruction. All codes reviewed before submission.