### PR TITLE
Support partial success for 2FA over auth API v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,15 +102,29 @@ PROXY protocol settings configures [PROXY protocol](https://www.haproxy.com/blog
 | `client_version`  | `string`              | SSH client identification string, e.g. `"SSH-2.0-OpenSSH_9.9"`.                                | Body     | Yes      |
 | `session_id`      | `string`              | Base64-encoded SSH session ID, unique per connection and stable across its auth requests.      | Body     | Yes      |
 | `method`          | `string`              | SSH authentication method. Usually one of `"none"`, `"publickey"` or `"keyboard-interactive"`. | Body     | Yes      |
-| `public_key`      | `string`              | User public key, serialized in OpenSSH format.                                                 | Body     | No       |
+| `public_key`      | `string`              | User public key, serialized in OpenSSH format. Kept on later requests once accepted.           | Body     | No       |
 | `payload`         | `Map<string, string>` | Authentication payload constructed from interactive input.                                     | Body     | No       |
 
 #### Output: `200 OK`
 
-| Key              | Type                    | Description                   | Required |
-| ---------------- | ----------------------- | ----------------------------- | -------- |
-| `upstream`       | [`Upstream`](#upstream) | SSH upstream information.     | Yes      |
-| `proxy`          | [`Proxy`](#proxy)       | PROXY protocol configuration. | No       |
+| Key              | Type                        | Description                                                                           | Required |
+| ---------------- | --------------------------- | ------------------------------------------------------------------------------------- | -------- |
+| `upstream`       | [`Upstream`](#upstream)     | SSH upstream information.                                                             | Yes, unless `challenges` is set |
+| `challenges`     | [`[]Challenge`](#challenge) | Challenges for extra inputs from user. Only applicable to `publickey` authentication. | No       |
+| `proxy`          | [`Proxy`](#proxy)           | PROXY protocol configuration.                                                         | No       |
+
+Returning `challenges` instead of `upstream` partially accepts the `publickey`
+authentication: `sshmux` reports partial success to the user and sends them to
+`keyboard-interactive`, the only method that can answer the challenges. Every
+other authentication request is rejected until such a request arrives, at which
+point the challenges are presented and their answers are sent back as `payload`
+of a new `keyboard-interactive` request, carrying over the accepted `public_key`.
+Further rounds of challenges are then requested with
+[`401 Not Authorized`](#output-401-not-authorized) as usual.
+
+Returning `200 OK` with neither `upstream` nor `challenges`, or returning
+`challenges` for an authentication method other than `publickey`, is an error
+and disconnects the user.
 
 ##### `Upstream`
 
@@ -135,6 +149,10 @@ PROXY protocol settings configures [PROXY protocol](https://www.haproxy.com/blog
 | Key          | Type                        | Description                                                                                      | Required |
 | ------------ | --------------------------- | ------------------------------------------------------------------------------------------------ | -------- |
 | `challenges` | [`[]Challenge`](#challenge) | Challenges for extra inputs from user. Only applicable to `keyboard-interactive` authentication. | Yes      |
+
+Returning `401 Not Authorized` no `challenges`, or returning `challenges` for an
+authentication method other than `keyboard-interactive`, is an error and
+disconnects the user.
 
 ##### `Challenge`
 

--- a/sshmux.go
+++ b/sshmux.go
@@ -195,6 +195,33 @@ func (s *Server) handler(conn net.Conn) {
 	}
 }
 
+// answerChallenges prompts the downstream user with the given challenges over
+// keyboard-interactive, and stores the collected answers into req's payload.
+func answerChallenges(session *ssh.PipeSession, req *AuthRequest, challenges []AuthChallenge) error {
+	for _, challenge := range challenges {
+		questions := make([]string, 0, len(challenge.Fields))
+		withEcho := make([]bool, 0, len(challenge.Fields))
+		for _, field := range challenge.Fields {
+			questions = append(questions, field.Prompt)
+			withEcho = append(withEcho, !field.Secret)
+		}
+		answers, err := session.Downstream.InteractiveChallenge("", challenge.Instruction, questions, withEcho)
+		if err != nil {
+			return err
+		}
+		if len(answers) != len(questions) {
+			return errors.New("ssh: numbers of answers and questions do not match")
+		}
+		if req.Payload == nil {
+			req.Payload = make(map[string]string, len(challenge.Fields))
+		}
+		for i, answer := range answers {
+			req.Payload[challenge.Fields[i].Key] = answer
+		}
+	}
+	return nil
+}
+
 func (s *Server) Handshake(session *ssh.PipeSession) error {
 	hasSetUser := false
 	var user string
@@ -210,6 +237,9 @@ func (s *Server) Handshake(session *ssh.PipeSession) error {
 	clientVersion := string(session.Downstream.ClientVersion())
 	sessionID := base64.StdEncoding.EncodeToString(session.Downstream.SessionID())
 	// Stage 1: Authenticate the user with API
+	// The public key accepted by the API server, carried over to the later auth
+	// requests, so that it can still recognize the user by it.
+	var acceptedPublicKey string
 auth_requests:
 	for {
 		authReq, err := session.Downstream.ReadAuthRequest(true)
@@ -226,6 +256,7 @@ auth_requests:
 			ClientVersion: clientVersion,
 			SessionID:     sessionID,
 			Method:        authReq.Method,
+			PublicKey:     acceptedPublicKey,
 		}
 		if authReq.Method == "publickey" && !authReq.IsPublicKeyQuery {
 			req.PublicKey = string(ssh.MarshalAuthorizedKey(*authReq.PublicKey))
@@ -237,6 +268,38 @@ auth_requests:
 			}
 			switch status {
 			case 200:
+				if resp.Upstream == nil {
+					// The API server partially accepts the publickey auth and requests
+					// challenges instead. Report the partial success and send the user
+					// to keyboard-interactive, the only method that can answer them.
+					if req.Method != "publickey" {
+						return fmt.Errorf("no upstream returned for user %s on %s auth", user, req.Method)
+					}
+					if len(resp.Challenges) == 0 {
+						return fmt.Errorf("neither upstream nor challenges returned for user %s", user)
+					}
+					acceptedPublicKey = req.PublicKey
+					err := session.Downstream.WriteAuthFailure([]string{"keyboard-interactive"}, true)
+					if err != nil {
+						return err
+					}
+					for {
+						authReq, err := session.Downstream.ReadAuthRequest(true)
+						if err != nil {
+							return err
+						}
+						if authReq.Method == "keyboard-interactive" {
+							req.Method = authReq.Method
+							break
+						}
+						session.Downstream.WriteAuthFailure([]string{"keyboard-interactive"}, false)
+					}
+					err = answerChallenges(session, &req, resp.Challenges)
+					if err != nil {
+						return err
+					}
+					continue
+				}
 				upstreamResp := *resp.Upstream
 				if upstreamResp.Port == 0 {
 					upstreamResp.Port = 22
@@ -283,26 +346,9 @@ auth_requests:
 					session.Downstream.WriteAuthFailure([]string{"publickey", "keyboard-interactive"}, false)
 					continue auth_requests
 				}
-				for _, challenge := range resp.Challenges {
-					questions := make([]string, 0, len(challenge.Fields))
-					withEcho := make([]bool, 0, len(challenge.Fields))
-					for _, field := range challenge.Fields {
-						questions = append(questions, field.Prompt)
-						withEcho = append(withEcho, !field.Secret)
-					}
-					answers, err := session.Downstream.InteractiveChallenge("", challenge.Instruction, questions, withEcho)
-					if err != nil {
-						return err
-					}
-					if len(answers) != len(questions) {
-						return errors.New("ssh: numbers of answers and questions do not match")
-					}
-					if req.Payload == nil {
-						req.Payload = make(map[string]string, len(challenge.Fields))
-					}
-					for i, answer := range answers {
-						req.Payload[challenge.Fields[i].Key] = answer
-					}
+				err := answerChallenges(session, &req, resp.Challenges)
+				if err != nil {
+					return err
 				}
 				continue
 			case 403:

--- a/sshmux_test.go
+++ b/sshmux_test.go
@@ -34,7 +34,12 @@ func localhostTCPAddr(port int) *net.TCPAddr {
 }
 
 var enableProxy bool
+var enablePartialAuth bool
 var inited bool
+
+// partialAuthToken is the answer expected by the auth API when partial auth is
+// enabled, before it hands out any upstream information.
+const partialAuthToken = "testtoken"
 
 // checkClientInfo validates the client information sshmux reports on an auth
 // request, and describes the first problem found, if any.
@@ -116,6 +121,51 @@ func initHttp(sshPrivateKey []byte) {
 			w.WriteHeader(http.StatusForbidden)
 			w.Write(jsonRes)
 			return
+		}
+
+		if enablePartialAuth {
+			deny := func(message string) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusForbidden)
+				w.Write([]byte(`{"failure":{"message":"` + message + `"}}`))
+			}
+			// The public key identifies the user, and must be carried over to the
+			// requests that follow its acceptance.
+			if req.PublicKey == "" {
+				deny("public key required")
+				return
+			}
+			switch req.Method {
+			case "publickey":
+				// Partially accept the public key, and ask for the token over
+				// keyboard-interactive.
+				res := map[string]any{
+					"challenges": []map[string]any{{
+						"instruction": "Please enter your token.",
+						"fields": []map[string]any{
+							{"key": "token", "prompt": "Token: ", "secret": true},
+						},
+					}},
+				}
+				jsonRes, err := json.Marshal(res)
+				if err != nil {
+					http.Error(w, "Cannot encode JSON", http.StatusInternalServerError)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.Write(jsonRes)
+				return
+			case "keyboard-interactive":
+				// The challenges are answered on the follow-up request, which the
+				// partial success has sent the user to.
+				if req.Payload["token"] != partialAuthToken {
+					deny("invalid token")
+					return
+				}
+			default:
+				deny("unsupported auth method")
+				return
+			}
 		}
 
 		res := map[string]any{
@@ -364,6 +414,74 @@ func testWithGolangSSHChallengeClient(t *testing.T, address *net.TCPAddr, descri
 	waitForSSHD(t, cmd)
 }
 
+func testWithGolangSSHPartialAuthClient(t *testing.T, address *net.TCPAddr, description string, proxy bool) {
+	challenged := false
+	challenge := func(user, instruction string, questions []string, echos []bool) (answers []string, err error) {
+		challenged = true
+		answers = make([]string, len(questions))
+		for i, q := range questions {
+			if strings.Contains(q, "Token") {
+				answers[i] = partialAuthToken
+			} else {
+				t.Fatalf("Unexpected question: %s", q)
+			}
+		}
+		return answers, nil
+	}
+
+	enableProxy = proxy
+	enablePartialAuth = true
+	defer func() { enablePartialAuth = false }()
+	cmd := onetimeSSHDServer(t)
+	time.Sleep(100 * time.Millisecond)
+
+	privateKey, err := os.ReadFile("fixtures/ssh_id_rsa")
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := ssh.ParsePrivateKey(privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	currentUser, err := user.Current()
+	if err != nil {
+		t.Fatalf("failed to get current user: %v", err)
+	}
+
+	config := &ssh.ClientConfig{
+		User: currentUser.Username,
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeys(signer),
+			ssh.KeyboardInteractive(challenge),
+		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         5 * time.Second,
+	}
+
+	client, err := ssh.Dial("tcp", address.String(), config)
+	if err != nil {
+		t.Fatal(fmt.Sprintf("%s: failed to dial: ", description), err)
+	}
+
+	if !challenged {
+		t.Fatalf("%s: expected a keyboard-interactive challenge after partial success", description)
+	}
+
+	session, err := client.NewSession()
+	if err != nil {
+		t.Fatal(fmt.Sprintf("%s: failed to create session: ", description), err)
+	}
+
+	if err := session.Run("uname"); err != nil {
+		t.Fatal(fmt.Sprintf("%s: failed to run command: ", description), err)
+	}
+
+	session.Close()
+	client.Close()
+
+	waitForSSHD(t, cmd)
+}
+
 func TestSSHClientConnection(t *testing.T) {
 	initEnv(t)
 	configFiles := []string{"config.toml", "legacy.toml", "config.json"}
@@ -427,4 +545,31 @@ func TestLegacySSHChallengeClientConnection(t *testing.T) {
 		// test sshmux with two-way proxy
 		testWithGolangSSHChallengeClient(t, sshmuxProxyAddr, "sshmux (proxied)", true)
 	}
+}
+
+func TestSSHPartialAuthChallengeClientConnection(t *testing.T) {
+	initEnv(t)
+
+	// start sshmux server
+	sshmux, err := sshmuxServer(filepath.Join("fixtures", "config.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = sshmux.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sshmux.Shutdown()
+
+	// test sshmux
+	testWithGolangSSHPartialAuthClient(t, sshmuxServerAddr, "sshmux", false)
+
+	// test sshmux with upstream proxy
+	testWithGolangSSHPartialAuthClient(t, sshmuxProxyAddr, "sshmux (proxied src)", false)
+
+	// test sshmux with downstream proxy
+	testWithGolangSSHPartialAuthClient(t, sshmuxServerAddr, "sshmux (proxied dst)", true)
+
+	// test sshmux with two-way proxy
+	testWithGolangSSHPartialAuthClient(t, sshmuxProxyAddr, "sshmux (proxied)", true)
 }


### PR DESCRIPTION
An auth API server can now answer `200 OK` with `challenges` and no `upstream`, which partially accepts a `publickey` authentication: sshmux reports partial success to the user and sends them to keyboard-interactive, the only method that can answer the challenges. Every other auth request is rejected until such a request arrives, at which point the challenges are presented and their answers are sent back as the payload of a new keyboard-interactive request. Further rounds of challenges are requested with `401 Not Authorized` as before.

The accepted public key is now carried over to the later auth requests, so that the API server can still recognize the user by it once the method is no longer `publickey`.

**Fixes:** Returning neither `upstream` nor `challenges` is now an error rather than a nil dereference, as is returning `challenges` for any other auth method; downstream error behavior is now fully documented in README.

**Rejected alternative:** This feature was initially designed in a simpler form, by accepting `401 Not Authorized` on `publickey` authentication. The idea was abandoned because per HTTP status convention, partial success should be expressed in `200 OK`, and mixing the two responses as the same shape makes them easier to be misused, compared to an explicit opt-in.

---

**Disclaimer:** This PR is designed and implemented in corporation with [Claude Code](https://claude.com/claude-code). Claude mostly takes over the test part, with human verification before submission.