### PR TITLE
Name metric attributes after the semantic conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ Prometheus settings configure the Prometheus scrape endpoint. They are grouped u
 | `enabled` | `bool`   | Whether the Prometheus endpoint is enabled. Defaults to `false`.         | No       | `true`               |
 | `address` | `string` | TCP host and port to serve metrics on. Defaults to `"127.0.0.1:9100"`.   | No       | `"127.0.0.1:9100"`   |
 | `path`    | `string` | HTTP path to serve metrics on. Defaults to `"/metrics"`.                 | No       | `"/metrics"`         |
+| `translation-strategy` | `string` | How OTLP names are rendered for Prometheus. One of `"UnderscoreEscapingWithSuffixes"` (default), `"NoUTF8EscapingWithSuffixes"` or `"NoTranslation"`. | No | `"NoTranslation"` |
+
+See the [OpenTelemetry Collector's Prometheus exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/prometheusexporter/README.md) for what each translation strategy does.
 
 ### PROXY Protocol Settings
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Metrics settings configure the [OpenTelemetry](https://opentelemetry.io) metrics
 | Key                | Type          | Description                                                                                                   | Required | Example                              |
 | ------------------ | ------------- | ------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------------ |
 | `enabled`          | `bool`        | Whether metrics collection is enabled. Defaults to `false`.                                                   | No       | `true`                               |
+| `convention`       | `string`      | Schema the attributes are named after, `"default"` or `"ecs"`. Defaults to `"default"`. See [Attribute Conventions](#attribute-conventions). | No | `"ecs"`          |
 | `service-name`     | `string`      | Value of the `service.name` resource attribute. Defaults to `"sshmux"`.                                       | No       | `"sshmux-vlab"`                      |
 | `attributes`       | `[]Attribute` | Extra resource attributes attached to every metric, e.g. to tag the deployment environment.                   | No       | `[{ name = "env", value = "prod" }]` |
 | `interval-seconds` | `uint`        | Interval at which metrics are pushed to the OTLP endpoint. Defaults to 60 seconds.                            | No       | `60`                                 |
@@ -146,6 +147,17 @@ PROXY protocol settings configures [PROXY protocol](https://www.haproxy.com/blog
 | `enabled`  | `bool`     | Whether PROXY protocol support is enabled. Defaults to `false`. | No       | `true`                          |
 | `hosts`    | `[]string` | Host names from which PROXY protocol is allowed.                | No       | `["nginx.local", "127.0.0.22"]` |
 | `networks` | `[]string` | Network CIDRs from which PROXY protocol is allowed.             | No       | `["10.10.0.0/24"]`              |
+
+## Attribute Conventions
+
+`metrics.convention` selects how each attribute is named:
+
+| Value | Resolves each attribute against |
+| --- | --- |
+| `default` | the [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/), then the [Elastic Common Schema](https://www.elastic.co/guide/en/ecs/current/index.html), then `sshmux` |
+| `ecs` | the [Elastic Common Schema](https://www.elastic.co/guide/en/ecs/current/index.html), then `sshmux` |
+
+They currently differ in no attribute.
 
 ## Metrics
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Metrics settings configure the [OpenTelemetry](https://opentelemetry.io) metrics
 | `service-name`     | `string`      | Value of the `service.name` resource attribute. Defaults to `"sshmux"`.                                       | No       | `"sshmux-vlab"`                      |
 | `attributes`       | `[]Attribute` | Extra resource attributes attached to every metric, e.g. to tag the deployment environment.                   | No       | `[{ name = "env", value = "prod" }]` |
 | `interval-seconds` | `uint`        | Interval at which metrics are pushed to the OTLP endpoint. Defaults to 60 seconds.                            | No       | `60`                                 |
-| `connection-grouping` | `bool`     | Whether the connection metrics carry the `username` and `upstream.address` dimensions. Defaults to `true`. See [Connection Grouping](#connection-grouping). | No | `false`   |
+| `connection-grouping` | `bool`     | Whether the connection metrics carry the `user.name`, `server.address` and `server.port` dimensions. Defaults to `true`. See [Connection Grouping](#connection-grouping). | No | `false`   |
 
 `Attribute` is a table with a `name` and a `value`, both `string`s.
 
@@ -156,29 +156,30 @@ The metric names below are the OpenTelemetry ones. The Prometheus endpoint rende
 | ---------------------------- | --------------- | -------------- | ---------------------------------------------- | ----------------------------------------------------------------- |
 | `sshmux.connections`         | Counter         | `{connection}` | —                                              | Connections accepted by `sshmux`.                                 |
 | `sshmux.connections.active`  | UpDownCounter   | `{connection}` | —                                              | Connections currently being served.                               |
-| `sshmux.sessions`            | Counter         | `{session}`    | `result`, `error.type`, `username`, `upstream.address` | Finished SSH proxy sessions.                              |
-| `sshmux.session.duration`    | Histogram       | `s`            | `result`, `error.type`, `username`, `upstream.address` | Session lifetime, from accept to close.                   |
-| `sshmux.handshake.duration`  | Histogram       | `s`            | `result`, `error.type`, `username`, `upstream.address` | Downstream handshake and authentication latency.          |
-| `sshmux.auth.requests`       | Counter         | `{request}`    | `result`, `error.type`, `auth.method`, `auth.status` | Requests sent to the auth API.                              |
-| `sshmux.auth.duration`       | Histogram       | `s`            | `result`, `error.type`, `auth.method`, `auth.status` | Auth API request latency.                                   |
-| `sshmux.upstream.connections`| Counter         | `{connection}` | `result`, `error.type`                         | Connection attempts to upstream SSH servers.                      |
+| `sshmux.sessions`            | Counter         | `{session}`    | `event.outcome`, `error.type`, [connection grouping](#connection-grouping) | Finished SSH proxy sessions.                          |
+| `sshmux.session.duration`    | Histogram       | `s`            | `event.outcome`, `error.type`, [connection grouping](#connection-grouping) | Session lifetime, from accept to close.               |
+| `sshmux.handshake.duration`  | Histogram       | `s`            | `event.outcome`, `error.type`, [connection grouping](#connection-grouping) | Downstream handshake and authentication latency.      |
+| `sshmux.auth.requests`       | Counter         | `{request}`    | `event.outcome`, `error.type`, `sshmux.auth.method`, `sshmux.auth.status` | Requests sent to the auth API.   |
+| `sshmux.auth.duration`       | Histogram       | `s`            | `event.outcome`, `error.type`, `sshmux.auth.method`, `sshmux.auth.status` | Auth API request latency.        |
+| `sshmux.upstream.connections`| Counter         | `{connection}` | `event.outcome`, `error.type`                     | Connection attempts to upstream SSH servers.          |
 
-`result` is either `success` or `failure`. On failure, `error.type` classifies the error as one of `eof`, `timeout`, `canceled`, `closed` or `other`. These sets are deliberately closed, so that a misbehaving client cannot blow up the time series cardinality.
+`event.outcome` is either `success` or `failure`. On failure, `error.type` classifies the error as one of `eof`, `timeout`, `canceled`, `closed` or `other`. These sets are deliberately closed, so that a misbehaving client cannot blow up the time series cardinality.
 
-For `sshmux.sessions` and `sshmux.session.duration`, `result` reports whether the session was *established*: an SSH client ends a healthy session by disconnecting, so how a session terminated once it was up is not counted against it. Use `sshmux.handshake.duration` to tell apart where an unestablished session failed.
+For `sshmux.sessions` and `sshmux.session.duration`, `event.outcome` reports whether the session was *established*: an SSH client ends a healthy session by disconnecting, so how a session terminated once it was up is not counted against it. Use `sshmux.handshake.duration` to tell apart where an unestablished session failed.
 
 ### Connection Grouping
 
-`sshmux.sessions`, `sshmux.session.duration` and `sshmux.handshake.duration` are grouped by two dimensions:
+`sshmux.sessions`, `sshmux.session.duration` and `sshmux.handshake.duration` are grouped by:
 
 | Attribute          | Description                                                                          |
 | ------------------ | ------------------------------------------------------------------------------------ |
-| `username`         | Username the client authenticated as.                                                |
-| `upstream.address` | Backend as `host:port`, as returned by the auth API and before any PROXY protocol override. |
+| `user.name`        | Username the client authenticated as.                                                |
+| `server.address`   | Backend host, as returned by the auth API and before any PROXY protocol override.    |
+| `server.port`      | Backend port, from the same response.                                                |
 
-Either is recorded as `unknown` when it is not yet known, which is the case for a connection that failed before its first auth request or before the auth API answered.
+Each is recorded as `unknown` when it is not yet known, which is the case for a connection that failed before its first auth request or before the auth API answered.
 
-`sshmux.connections` and `sshmux.connections.active` are recorded when a connection is accepted, before either dimension is known, so they carry no grouping.
+`sshmux.connections` and `sshmux.connections.active` are recorded when a connection is accepted, before any of them is known, so they carry no grouping.
 
 Setting `metrics.connection-grouping` to `false` drops both dimensions, leaving one series per outcome.
 

--- a/config.go
+++ b/config.go
@@ -55,6 +55,7 @@ type RecoveryConfig struct {
 
 type MetricsConfig struct {
 	Enabled            bool                     `toml:"enabled"`
+	Convention         MetricsConvention        `toml:"convention,omitempty"`
 	ServiceName        string                   `toml:"service-name,omitempty"`
 	Attributes         []MetricsAttributeConfig `toml:"attributes,omitempty"`
 	IntervalSeconds    uint                     `toml:"interval-seconds,omitempty"`
@@ -109,6 +110,30 @@ type LegacyConfig struct {
 	UsernameNoPassword     []string `json:"username-nopassword"`
 	InvalidUsername        []string `json:"invalid-username"`
 	InvalidUsernameMessage string   `json:"invalid-username-message"`
+}
+
+// MetricsConvention names the schema the metric attributes follow.
+type MetricsConvention string
+
+const (
+	// MetricsConventionDefault resolves each attribute against the
+	// OpenTelemetry semantic conventions, then the Elastic Common Schema, then
+	// sshmux's own namespace, and follows the conventions wherever they move.
+	MetricsConventionDefault MetricsConvention = "default"
+	// MetricsConventionECS resolves against the Elastic Common Schema only,
+	// which does not move.
+	MetricsConventionECS MetricsConvention = "ecs"
+)
+
+func (c *MetricsConvention) UnmarshalText(text []byte) error {
+	switch value := MetricsConvention(text); value {
+	case "", MetricsConventionDefault, MetricsConventionECS:
+		*c = value
+		return nil
+	default:
+		return fmt.Errorf("unsupported metrics convention %q, want %q or %q",
+			value, MetricsConventionDefault, MetricsConventionECS)
+	}
 }
 
 // PrometheusTranslationStrategy names how OTLP names are rendered for

--- a/config.go
+++ b/config.go
@@ -77,9 +77,10 @@ type MetricsOTLPConfig struct {
 }
 
 type MetricsPrometheusConfig struct {
-	Enabled bool   `toml:"enabled"`
-	Address string `toml:"address,omitempty"`
-	Path    string `toml:"path,omitempty"`
+	Enabled             bool                          `toml:"enabled"`
+	Address             string                        `toml:"address,omitempty"`
+	Path                string                        `toml:"path,omitempty"`
+	TranslationStrategy PrometheusTranslationStrategy `toml:"translation-strategy,omitempty"`
 }
 
 type Config struct {
@@ -108,6 +109,33 @@ type LegacyConfig struct {
 	UsernameNoPassword     []string `json:"username-nopassword"`
 	InvalidUsername        []string `json:"invalid-username"`
 	InvalidUsernameMessage string   `json:"invalid-username-message"`
+}
+
+// PrometheusTranslationStrategy names how OTLP names are rendered for
+// Prometheus. The values are the ones the OpenTelemetry Collector's Prometheus
+// exporter accepts, less UnderscoreEscapingWithoutSuffixes, which Prometheus
+// does not support directly.
+type PrometheusTranslationStrategy string
+
+const (
+	// UnderscoreEscaping replaces discouraged characters with `_` and appends
+	// the type and unit suffixes, as the specification recommends.
+	UnderscoreEscaping PrometheusTranslationStrategy = "UnderscoreEscapingWithSuffixes"
+	// NoUTF8Escaping keeps the OTLP names, but still appends the suffixes.
+	NoUTF8Escaping PrometheusTranslationStrategy = "NoUTF8EscapingWithSuffixes"
+	// NoTranslation passes names through untouched, suffixes included.
+	NoTranslation PrometheusTranslationStrategy = "NoTranslation"
+)
+
+func (s *PrometheusTranslationStrategy) UnmarshalText(text []byte) error {
+	switch value := PrometheusTranslationStrategy(text); value {
+	case "", UnderscoreEscaping, NoUTF8Escaping, NoTranslation:
+		*s = value
+		return nil
+	default:
+		return fmt.Errorf("unsupported Prometheus translation strategy %q, want %q, %q or %q",
+			value, UnderscoreEscaping, NoUTF8Escaping, NoTranslation)
+	}
 }
 
 type ProxyPolicyConfig struct {

--- a/config_test.go
+++ b/config_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"fmt"
 	"net/netip"
 	"testing"
+
+	"github.com/pelletier/go-toml/v2"
 )
 
 // configFixture pairs a configuration file under `fixtures` with the values it
@@ -239,4 +242,36 @@ func TestConvertProxyPolicyConfig(t *testing.T) {
 	if len(policy.AllowedCIDRs) != 0 || len(policy.AllowedHosts) != 0 {
 		t.Errorf("disabled policy = %+v, want empty", policy)
 	}
+}
+
+// TestEnumeratedMetricsKeys checks that a good translation strategy decodes,
+// that a bad one is refused while parsing rather than later, and that every
+// accepted value resolves.
+func TestEnumeratedMetricsKeys(t *testing.T) {
+	strategies := []PrometheusTranslationStrategy{UnderscoreEscaping, NoUTF8Escaping, NoTranslation}
+
+	var config Config
+	for _, strategy := range strategies {
+		toml := fmt.Sprintf("[metrics.prometheus]\ntranslation-strategy = %q\n", strategy)
+		if err := unmarshalConfig(toml, &config); err != nil {
+			t.Errorf("strategy %q: %v", strategy, err)
+		}
+	}
+
+	// A bad value fails while the file is being read, so the error can name it.
+	// Prometheus does not support this one, so it is not among the accepted values.
+	if err := unmarshalConfig("[metrics.prometheus]\ntranslation-strategy = \"UnderscoreEscapingWithoutSuffixes\"\n", &config); err == nil {
+		t.Error("UnderscoreEscapingWithoutSuffixes should be refused while parsing")
+	}
+
+	// Every accepted value must resolve, or the type and the resolver drifted.
+	for _, strategy := range strategies {
+		if _, err := prometheusTranslationStrategy(strategy); err != nil {
+			t.Errorf("strategy %q is accepted but does not resolve: %v", strategy, err)
+		}
+	}
+}
+
+func unmarshalConfig(text string, config *Config) error {
+	return toml.Unmarshal([]byte(text), config)
 }

--- a/config_test.go
+++ b/config_test.go
@@ -244,14 +244,24 @@ func TestConvertProxyPolicyConfig(t *testing.T) {
 	}
 }
 
-// TestEnumeratedMetricsKeys checks that a good translation strategy decodes,
-// that a bad one is refused while parsing rather than later, and that every
-// accepted value resolves.
+// TestEnumeratedMetricsKeys checks the keys whose accepted values config.go
+// declares as types: that a good value decodes, that a bad one is refused
+// while parsing rather than later, and that every accepted value resolves.
 func TestEnumeratedMetricsKeys(t *testing.T) {
+	conventions := []MetricsConvention{MetricsConventionDefault, MetricsConventionECS}
 	strategies := []PrometheusTranslationStrategy{UnderscoreEscaping, NoUTF8Escaping, NoTranslation}
 
-	var config Config
+	for _, convention := range conventions {
+		var config Config
+		toml := fmt.Sprintf("[metrics]\nconvention = %q\n", convention)
+		if err := unmarshalConfig(toml, &config); err != nil {
+			t.Errorf("convention %q: %v", convention, err)
+		} else if config.Metrics.Convention != convention {
+			t.Errorf("convention decoded as %q, want %q", config.Metrics.Convention, convention)
+		}
+	}
 	for _, strategy := range strategies {
+		var config Config
 		toml := fmt.Sprintf("[metrics.prometheus]\ntranslation-strategy = %q\n", strategy)
 		if err := unmarshalConfig(toml, &config); err != nil {
 			t.Errorf("strategy %q: %v", strategy, err)
@@ -259,12 +269,21 @@ func TestEnumeratedMetricsKeys(t *testing.T) {
 	}
 
 	// A bad value fails while the file is being read, so the error can name it.
+	var config Config
+	if err := unmarshalConfig("[metrics]\nconvention = \"nonsense\"\n", &config); err == nil {
+		t.Error("an unknown convention should be refused while parsing")
+	}
 	// Prometheus does not support this one, so it is not among the accepted values.
 	if err := unmarshalConfig("[metrics.prometheus]\ntranslation-strategy = \"UnderscoreEscapingWithoutSuffixes\"\n", &config); err == nil {
 		t.Error("UnderscoreEscapingWithoutSuffixes should be refused while parsing")
 	}
 
 	// Every accepted value must resolve, or the type and the resolver drifted.
+	for _, convention := range conventions {
+		if _, err := conventionAttributeNames(convention); err != nil {
+			t.Errorf("convention %q is accepted but does not resolve: %v", convention, err)
+		}
+	}
 	for _, strategy := range strategies {
 		if _, err := prometheusTranslationStrategy(strategy); err != nil {
 			t.Errorf("strategy %q is accepted but does not resolve: %v", strategy, err)

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require github.com/pelletier/go-toml/v2 v2.2.2
 require (
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/prometheus/client_golang v1.24.1
+	github.com/prometheus/otlptranslator v1.0.0
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.45.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.45.0
@@ -33,7 +34,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.1 // indirect
-	github.com/prometheus/otlptranslator v1.0.0 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/trace v1.45.0 // indirect

--- a/metrics.go
+++ b/metrics.go
@@ -45,29 +45,62 @@ const (
 	envOTLPMetricsProtocol = "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"
 )
 
-// From the OpenTelemetry semantic conventions.
-const (
-	attrErrorType     = attribute.Key("error.type")
-	attrUserName      = attribute.Key("user.name")
-	attrServerAddress = attribute.Key("server.address")
-	attrServerPort    = attribute.Key("server.port")
-)
+// attributeNames is the set of attribute keys one convention resolves to.
+// Only the names differ between conventions; the values never do.
+type attributeNames struct {
+	result        attribute.Key
+	errorType     attribute.Key
+	userName      attribute.Key
+	serverAddress attribute.Key
+	serverPort    attribute.Key
+	authMethod    attribute.Key
+	authStatus    attribute.Key
+}
 
-// From the Elastic Common Schema, which the semantic conventions have no
-// equivalent for yet.
-const attrResult = attribute.Key("event.outcome")
+// defaultAttributeNames resolves each attribute against the OpenTelemetry
+// semantic conventions first, then the Elastic Common Schema, then sshmux's
+// own namespace, and follows the conventions wherever they move.
+var defaultAttributeNames = attributeNames{
+	errorType:     attribute.Key("error.type"),     // semconv
+	userName:      attribute.Key("user.name"),      // semconv
+	serverAddress: attribute.Key("server.address"), // semconv
+	serverPort:    attribute.Key("server.port"),    // semconv
+	result:        attribute.Key("event.outcome"),  // ECS; semconv has no equivalent
+	authMethod:    attribute.Key("sshmux.auth.method"),
+	authStatus:    attribute.Key("sshmux.auth.status"),
+}
 
-// sshmux's own, namespaced so that they cannot collide with a future
-// convention. Neither schema describes an authentication method.
-const (
-	attrAuthMethod = attribute.Key("sshmux.auth.method")
-	attrAuthStatus = attribute.Key("sshmux.auth.status")
-)
+// ecsAttributeNames resolves against the Elastic Common Schema only, which does
+// not move when the semantic conventions do.
+//
+// It currently names every attribute identically to defaultAttributeNames,
+// because the conventions adopted these fields from ECS. The two are kept
+// apart so that they can diverge without the configuration changing shape.
+var ecsAttributeNames = attributeNames{
+	errorType:     attribute.Key("error.type"),
+	userName:      attribute.Key("user.name"),
+	serverAddress: attribute.Key("server.address"),
+	serverPort:    attribute.Key("server.port"),
+	result:        attribute.Key("event.outcome"),
+	authMethod:    attribute.Key("sshmux.auth.method"),
+	authStatus:    attribute.Key("sshmux.auth.status"),
+}
 
-var (
-	resultSuccess = attrResult.String("success")
-	resultFailure = attrResult.String("failure")
-)
+// conventionAttributeNames resolves the configured convention.
+func conventionAttributeNames(convention MetricsConvention) (attributeNames, error) {
+	switch convention {
+	case "", MetricsConventionDefault:
+		return defaultAttributeNames, nil
+	case MetricsConventionECS:
+		return ecsAttributeNames, nil
+	default:
+		// Unreachable: validateMetricsConfig accepts only the names above.
+		return attributeNames{}, fmt.Errorf("unsupported convention: %s", convention)
+	}
+}
+
+func (n attributeNames) success() attribute.KeyValue { return n.result.String("success") }
+func (n attributeNames) failure() attribute.KeyValue { return n.result.String("failure") }
 
 // connectionInfo is the per-connection state reported to the metrics recorder.
 // Fields are zero until they become known: Username is only set once the client
@@ -91,7 +124,9 @@ type Metrics struct {
 	// groupConnections reports whether the connection metrics carry the username
 	// and upstream dimensions.
 	groupConnections bool
-	provider         *sdkmetric.MeterProvider
+	// attrs holds the attribute names the configured convention resolved to.
+	attrs    attributeNames
+	provider *sdkmetric.MeterProvider
 
 	promAddress  string
 	promPath     string
@@ -110,9 +145,14 @@ type Metrics struct {
 }
 
 func makeMetrics(config MetricsConfig) (*Metrics, error) {
+	names, err := conventionAttributeNames(config.Convention)
+	if err != nil {
+		return nil, err
+	}
 	metrics := &Metrics{
 		enabled:          config.Enabled,
 		groupConnections: boolOrDefault(config.ConnectionGrouping, true),
+		attrs:            names,
 	}
 	if !config.Enabled {
 		return newMetrics(metrics, noop.NewMeterProvider().Meter(metricsScopeName))
@@ -482,14 +522,14 @@ func (m *Metrics) UpstreamDialed(ctx context.Context, err error) {
 	if !m.enabled {
 		return
 	}
-	m.upstreamTotal.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(resultAttributes(err)...)))
+	m.upstreamTotal.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(m.attrs.resultAttributes(err)...)))
 }
 
 func (m *Metrics) AuthFinished(ctx context.Context, method string, status int, err error, duration time.Duration) {
 	if !m.enabled {
 		return
 	}
-	attrs := append(resultAttributes(err), attrAuthMethod.String(method), attrAuthStatus.Int(status))
+	attrs := append(m.attrs.resultAttributes(err), m.attrs.authMethod.String(method), m.attrs.authStatus.Int(status))
 	set := metric.WithAttributeSet(attribute.NewSet(attrs...))
 	m.authRequestsTotal.Add(ctx, 1, set)
 	m.authDuration.Record(ctx, duration.Seconds(), set)
@@ -499,22 +539,22 @@ func (m *Metrics) AuthFinished(ctx context.Context, method string, status int, e
 // dimensions the connection metrics are grouped by, unless the grouping has
 // been turned off.
 func (m *Metrics) connectionAttributeSet(info connectionInfo, err error) attribute.Set {
-	attrs := resultAttributes(err)
+	attrs := m.attrs.resultAttributes(err)
 	if m.groupConnections {
 		attrs = append(attrs,
-			attrUserName.String(valueOrDefault(info.Username, unknownAttributeValue)),
-			attrServerAddress.String(valueOrDefault(info.UpstreamHost, unknownAttributeValue)),
-			attrServerPort.Int(int(info.UpstreamPort)),
+			m.attrs.userName.String(valueOrDefault(info.Username, unknownAttributeValue)),
+			m.attrs.serverAddress.String(valueOrDefault(info.UpstreamHost, unknownAttributeValue)),
+			m.attrs.serverPort.Int(int(info.UpstreamPort)),
 		)
 	}
 	return attribute.NewSet(attrs...)
 }
 
-func resultAttributes(err error) []attribute.KeyValue {
+func (n attributeNames) resultAttributes(err error) []attribute.KeyValue {
 	if err == nil {
-		return []attribute.KeyValue{resultSuccess}
+		return []attribute.KeyValue{n.success()}
 	}
-	return []attribute.KeyValue{resultFailure, attrErrorType.String(errorType(err))}
+	return []attribute.KeyValue{n.failure(), n.errorType.String(errorType(err))}
 }
 
 func errorType(err error) string {

--- a/metrics.go
+++ b/metrics.go
@@ -46,12 +46,18 @@ const (
 
 // Attribute keys shared by the instruments below.
 const (
-	attrResult          = attribute.Key("result")
-	attrErrorType       = attribute.Key("error.type")
-	attrAuthMethod      = attribute.Key("auth.method")
-	attrAuthStatus      = attribute.Key("auth.status")
-	attrUsername        = attribute.Key("username")
-	attrUpstreamAddress = attribute.Key("upstream.address")
+	// From the OpenTelemetry semantic conventions.
+	attrErrorType     = attribute.Key("error.type")
+	attrUserName      = attribute.Key("user.name")
+	attrServerAddress = attribute.Key("server.address")
+	attrServerPort    = attribute.Key("server.port")
+	// From the Elastic Common Schema, which the semantic conventions have no
+	// equivalent for yet.
+	attrResult = attribute.Key("event.outcome")
+	// sshmux's own, namespaced so that they cannot collide with a future
+	// convention. Neither schema describes an authentication method.
+	attrAuthMethod = attribute.Key("sshmux.auth.method")
+	attrAuthStatus = attribute.Key("sshmux.auth.status")
 )
 
 var (
@@ -61,13 +67,14 @@ var (
 
 // connectionInfo is the per-connection state reported to the metrics recorder.
 // Fields are zero until they become known: Username is only set once the client
-// has sent its first auth request, and Upstream only once the auth API has
+// has sent its first auth request, and the upstream only once the auth API has
 // answered.
 type connectionInfo struct {
 	Username string
-	// Upstream is the backend address as host:port, as returned by the auth API
-	// and before any PROXY protocol override.
-	Upstream string
+	// UpstreamHost and UpstreamPort are the backend the auth API returned,
+	// before any PROXY protocol override.
+	UpstreamHost string
+	UpstreamPort uint16
 	// Established records whether the handshake completed.
 	Established bool
 }
@@ -462,8 +469,9 @@ func (m *Metrics) connectionAttributeSet(info connectionInfo, err error) attribu
 	attrs := resultAttributes(err)
 	if m.groupConnections {
 		attrs = append(attrs,
-			attrUsername.String(valueOrDefault(info.Username, unknownAttributeValue)),
-			attrUpstreamAddress.String(valueOrDefault(info.Upstream, unknownAttributeValue)),
+			attrUserName.String(valueOrDefault(info.Username, unknownAttributeValue)),
+			attrServerAddress.String(valueOrDefault(info.UpstreamHost, unknownAttributeValue)),
+			attrServerPort.Int(int(info.UpstreamPort)),
 		)
 	}
 	return attribute.NewSet(attrs...)

--- a/metrics.go
+++ b/metrics.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/otlptranslator"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
@@ -44,18 +45,21 @@ const (
 	envOTLPMetricsProtocol = "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"
 )
 
-// Attribute keys shared by the instruments below.
+// From the OpenTelemetry semantic conventions.
 const (
-	// From the OpenTelemetry semantic conventions.
 	attrErrorType     = attribute.Key("error.type")
 	attrUserName      = attribute.Key("user.name")
 	attrServerAddress = attribute.Key("server.address")
 	attrServerPort    = attribute.Key("server.port")
-	// From the Elastic Common Schema, which the semantic conventions have no
-	// equivalent for yet.
-	attrResult = attribute.Key("event.outcome")
-	// sshmux's own, namespaced so that they cannot collide with a future
-	// convention. Neither schema describes an authentication method.
+)
+
+// From the Elastic Common Schema, which the semantic conventions have no
+// equivalent for yet.
+const attrResult = attribute.Key("event.outcome")
+
+// sshmux's own, namespaced so that they cannot collide with a future
+// convention. Neither schema describes an authentication method.
+const (
 	attrAuthMethod = attribute.Key("sshmux.auth.method")
 	attrAuthStatus = attribute.Key("sshmux.auth.status")
 )
@@ -131,8 +135,16 @@ func makeMetrics(config MetricsConfig) (*Metrics, error) {
 		readers = append(readers, sdkmetric.NewPeriodicReader(exporter, readerOptions...))
 	}
 	if config.Prometheus.Enabled {
+		strategy, err := prometheusTranslationStrategy(config.Prometheus.TranslationStrategy)
+		if err != nil {
+			return nil, err
+		}
 		registry := prometheus.NewRegistry()
-		reader, err := otelprom.New(otelprom.WithRegisterer(registry), otelprom.WithoutScopeInfo())
+		reader, err := otelprom.New(
+			otelprom.WithRegisterer(registry),
+			otelprom.WithoutScopeInfo(),
+			otelprom.WithTranslationStrategy(strategy),
+		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to set up Prometheus exporter: %w", err)
 		}
@@ -163,6 +175,27 @@ func makeMetrics(config MetricsConfig) (*Metrics, error) {
 	}
 	metrics.provider = sdkmetric.NewMeterProvider(options...)
 	return newMetrics(metrics, metrics.provider.Meter(metricsScopeName))
+}
+
+// prometheusTranslationStrategy resolves how OTLP names are rendered for
+// Prometheus. The names are the ones the OpenTelemetry Collector's Prometheus
+// exporter uses, so that a strategy can be carried over from a collector
+// configuration unchanged.
+//
+// UnderscoreEscapingWithoutSuffixes is deliberately not accepted: Prometheus
+// does not support it directly and it is rarely wanted.
+func prometheusTranslationStrategy(configured PrometheusTranslationStrategy) (otlptranslator.TranslationStrategyOption, error) {
+	switch configured {
+	case "", UnderscoreEscaping:
+		return otlptranslator.UnderscoreEscapingWithSuffixes, nil
+	case NoUTF8Escaping:
+		return otlptranslator.NoUTF8EscapingWithSuffixes, nil
+	case NoTranslation:
+		return otlptranslator.NoTranslation, nil
+	default:
+		// Unreachable: validateMetricsConfig accepts only the names above.
+		return "", fmt.Errorf("unsupported Prometheus translation strategy: %s", configured)
+	}
 }
 
 // durationViews replaces the SDK's default histogram buckets, which are tuned

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -859,3 +859,68 @@ func TestPrometheusTranslationStrategy(t *testing.T) {
 		}
 	})
 }
+
+// TestConventionAttributeNames pins how each convention resolves, and that the
+// two lines currently agree — the property that lets `ecs` be the stable choice
+// today at no cost.
+func TestConventionAttributeNames(t *testing.T) {
+	for _, convention := range []MetricsConvention{"", MetricsConventionDefault} {
+		names, err := conventionAttributeNames(convention)
+		if err != nil {
+			t.Fatalf("convention %q: %v", convention, err)
+		}
+		if names != defaultAttributeNames {
+			t.Errorf("convention %q did not resolve to the semantic conventions", convention)
+		}
+	}
+	names, err := conventionAttributeNames(MetricsConventionECS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if names != ecsAttributeNames {
+		t.Error(`convention "ecs" did not resolve to the Elastic Common Schema`)
+	}
+
+	// The conventions adopted these fields from ECS, so the two lines name
+	// every attribute identically. This will stop holding when they diverge,
+	// and the test is what will say so.
+	if defaultAttributeNames != ecsAttributeNames {
+		t.Log("the conventions have diverged; the README table needs updating")
+	}
+
+	if _, err := conventionAttributeNames("nonsense"); err == nil {
+		t.Error("an unknown convention should be refused")
+	}
+}
+
+// TestConventionEndToEnd checks that the configured convention reaches the
+// exported labels.
+func TestConventionEndToEnd(t *testing.T) {
+	for _, convention := range []MetricsConvention{MetricsConventionDefault, MetricsConventionECS} {
+		t.Run(string(convention), func(t *testing.T) {
+			metrics, err := makeMetrics(MetricsConfig{
+				Enabled:    true,
+				Convention: convention,
+				Prometheus: MetricsPrometheusConfig{Enabled: true, Address: "127.0.0.1:0"},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := metrics.Start(); err != nil {
+				t.Fatal(err)
+			}
+			defer metrics.Shutdown(t.Context())
+
+			metrics.ConnectionClosed(t.Context(), testConnection, nil, time.Second)
+			want := `sshmux_sessions_total{event_outcome="success",server_address="10.0.0.7",server_port="22",user_name="vlab"} 1`
+			if body := scrape(t, metrics); !strings.Contains(body, want) {
+				t.Errorf("scrape does not contain %q:\n%s", want, body)
+			}
+		})
+	}
+
+	// A value that never came from a configuration file still cannot slip past.
+	if _, err := makeMetrics(MetricsConfig{Enabled: true, Convention: "nonsense"}); err == nil {
+		t.Error("an unknown convention should be refused at startup")
+	}
+}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -766,3 +766,96 @@ func TestConnectionGroupingDisabled(t *testing.T) {
 		t.Errorf("scrape output does not contain %q:\n%s", want, body)
 	}
 }
+
+// scrapeAs fetches the Prometheus endpoint with a given Accept header, so that
+// UTF-8 name negotiation can be exercised.
+func scrapeAs(t *testing.T, metrics *Metrics, accept string) string {
+	t.Helper()
+	request, err := http.NewRequest("GET", fmt.Sprintf("http://%s%s", metrics.PrometheusAddr(), metrics.promPath), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Accept", accept)
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(body)
+}
+
+// startPrometheus brings up a Metrics with only the Prometheus endpoint, on the
+// given translation strategy, and records one session.
+func startPrometheus(t *testing.T, strategy PrometheusTranslationStrategy) *Metrics {
+	t.Helper()
+	metrics, err := makeMetrics(MetricsConfig{
+		Enabled: true,
+		Prometheus: MetricsPrometheusConfig{
+			Enabled: true, Address: "127.0.0.1:0", TranslationStrategy: strategy,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := metrics.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { metrics.Shutdown(context.Background()) })
+	metrics.ConnectionClosed(t.Context(), testConnection, nil, time.Second)
+	return metrics
+}
+
+// TestPrometheusTranslationStrategy pins what each accepted strategy actually
+// produces. Note that a scraper only ever sees the untranslated names if it
+// negotiates UTF-8; without that the exposition escapes them regardless.
+func TestPrometheusTranslationStrategy(t *testing.T) {
+	const utf8Accept = "text/plain;version=1.0.0;escaping=allow-utf-8"
+
+	t.Run("escaped by default", func(t *testing.T) {
+		for _, strategy := range []PrometheusTranslationStrategy{"", UnderscoreEscaping} {
+			body := scrape(t, startPrometheus(t, strategy))
+			if !strings.Contains(body, `sshmux_sessions_total{`) {
+				t.Errorf("strategy %q: no escaped name with suffix:\n%s", strategy, body)
+			}
+		}
+	})
+
+	t.Run("NoTranslation drops the suffix", func(t *testing.T) {
+		body := scrape(t, startPrometheus(t, NoTranslation))
+		if !strings.Contains(body, `sshmux_sessions{`) {
+			t.Errorf("no unsuffixed name:\n%s", body)
+		}
+		if strings.Contains(body, `sshmux_sessions_total{`) {
+			t.Error("the _total suffix should not be added")
+		}
+	})
+
+	t.Run("dots survive for a UTF-8 scraper", func(t *testing.T) {
+		metrics := startPrometheus(t, NoUTF8Escaping)
+		if body := scrapeAs(t, metrics, utf8Accept); !strings.Contains(body, `{"sshmux.sessions_total"`) ||
+			!strings.Contains(body, `"user.name"="vlab"`) {
+			t.Errorf("names were escaped despite negotiation:\n%s", body)
+		}
+		// The same endpoint still escapes for a scraper that does not ask.
+		if body := scrape(t, metrics); !strings.Contains(body, `sshmux_sessions_total{`) {
+			t.Errorf("names were not escaped for a plain scraper:\n%s", body)
+		}
+	})
+
+	t.Run("rejected values", func(t *testing.T) {
+		// Prometheus does not support this one directly.
+		for _, strategy := range []PrometheusTranslationStrategy{"UnderscoreEscapingWithoutSuffixes", "nonsense"} {
+			_, err := makeMetrics(MetricsConfig{
+				Enabled:    true,
+				Prometheus: MetricsPrometheusConfig{Enabled: true, TranslationStrategy: strategy},
+			})
+			if err == nil {
+				t.Errorf("strategy %q should be rejected", strategy)
+			}
+		}
+	})
+}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -22,9 +22,10 @@ import (
 
 // testConnection is the connection identity used by the metric assertions.
 var testConnection = connectionInfo{
-	Username:    "vlab",
-	Upstream:    "10.0.0.7:22",
-	Established: true,
+	Username:     "vlab",
+	UpstreamHost: "10.0.0.7",
+	UpstreamPort: 22,
+	Established:  true,
 }
 
 // prometheusMetrics starts a Metrics instance with only the Prometheus
@@ -109,13 +110,13 @@ func TestMetricsPrometheusEndpoint(t *testing.T) {
 	metrics.ConnectionClosed(ctx, testConnection, os.ErrDeadlineExceeded, 2*time.Second)
 
 	body := scrape(t, metrics)
-	const group = `result="success",upstream_address="10.0.0.7:22",username="vlab"`
+	const group = `event_outcome="success",server_address="10.0.0.7",server_port="22",user_name="vlab"`
 	for _, want := range []string{
 		`sshmux_connections_total 2`,
 		`sshmux_connections_active 0`,
 		`sshmux_sessions_total{` + group + `} 1`,
-		`sshmux_sessions_total{error_type="timeout",result="failure",upstream_address="10.0.0.7:22",username="vlab"} 1`,
-		`sshmux_upstream_connections_total{result="success"} 1`,
+		`sshmux_sessions_total{error_type="timeout",event_outcome="failure",server_address="10.0.0.7",server_port="22",user_name="vlab"} 1`,
+		`sshmux_upstream_connections_total{event_outcome="success"} 1`,
 		`sshmux_session_duration_seconds_count{` + group + `} 1`,
 		`sshmux_handshake_duration_seconds_count{` + group + `} 1`,
 	} {
@@ -171,9 +172,9 @@ func TestInstrumentedAuthenticator(t *testing.T) {
 
 	body := scrape(t, metrics)
 	for _, want := range []string{
-		`sshmux_auth_requests_total{auth_method="publickey",auth_status="401",result="success"} 1`,
-		`sshmux_auth_requests_total{auth_method="keyboard-interactive",auth_status="0",error_type="eof",result="failure"} 1`,
-		`sshmux_auth_duration_seconds_count{auth_method="publickey",auth_status="401",result="success"} 1`,
+		`sshmux_auth_requests_total{event_outcome="success",sshmux_auth_method="publickey",sshmux_auth_status="401"} 1`,
+		`sshmux_auth_requests_total{error_type="eof",event_outcome="failure",sshmux_auth_method="keyboard-interactive",sshmux_auth_status="0"} 1`,
+		`sshmux_auth_duration_seconds_count{event_outcome="success",sshmux_auth_method="publickey",sshmux_auth_status="401"} 1`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("scrape output does not contain %q:\n%s", want, body)
@@ -359,9 +360,9 @@ func TestConnectionGrouping(t *testing.T) {
 
 	body := scrape(t, metrics)
 	for _, want := range []string{
-		`sshmux_sessions_total{result="success",upstream_address="10.0.0.7:22",username="vlab"} 1`,
-		`sshmux_session_duration_seconds_count{result="success",upstream_address="10.0.0.7:22",username="vlab"} 1`,
-		`sshmux_sessions_total{error_type="eof",result="failure",upstream_address="unknown",username="unknown"} 1`,
+		`sshmux_sessions_total{event_outcome="success",server_address="10.0.0.7",server_port="22",user_name="vlab"} 1`,
+		`sshmux_session_duration_seconds_count{event_outcome="success",server_address="10.0.0.7",server_port="22",user_name="vlab"} 1`,
+		`sshmux_sessions_total{error_type="eof",event_outcome="failure",server_address="unknown",server_port="0",user_name="unknown"} 1`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("scrape output does not contain %q:\n%s", want, body)
@@ -673,8 +674,8 @@ func TestServerMetricsUpstreamGrouping(t *testing.T) {
 
 	// The session is recorded once its handler winds down, shortly after the
 	// client exits.
-	want := fmt.Sprintf(`sshmux_sessions_total{result="success",upstream_address=%q,username=%q} 1`,
-		sshdServerAddr.String(), currentUser.Username)
+	want := fmt.Sprintf(`sshmux_sessions_total{event_outcome="success",server_address=%q,server_port="%d",user_name=%q} 1`,
+		sshdServerAddr.IP.String(), sshdServerAddr.Port, currentUser.Username)
 	deadline := time.Now().Add(5 * time.Second)
 	var body string
 	for time.Now().Before(deadline) {
@@ -704,9 +705,10 @@ func recordSessions(t *testing.T, metrics *Metrics, count int) {
 	t.Helper()
 	for i := range count {
 		info := connectionInfo{
-			Username:    fmt.Sprintf("user%d", i),
-			Upstream:    fmt.Sprintf("10.0.0.%d:22", i),
-			Established: true,
+			Username:     fmt.Sprintf("user%d", i),
+			UpstreamHost: fmt.Sprintf("10.0.0.%d", i),
+			UpstreamPort: 22,
+			Established:  true,
 		}
 		metrics.ConnectionClosed(t.Context(), info, nil, time.Second)
 	}
@@ -760,7 +762,7 @@ func TestConnectionGroupingDisabled(t *testing.T) {
 			t.Errorf("scrape output still contains %q:\n%s", unwanted, body)
 		}
 	}
-	if want := `sshmux_sessions_total{result="success"} 2500`; !strings.Contains(body, want) {
+	if want := `sshmux_sessions_total{event_outcome="success"} 2500`; !strings.Contains(body, want) {
 		t.Errorf("scrape output does not contain %q:\n%s", want, body)
 	}
 }

--- a/sshmux.go
+++ b/sshmux.go
@@ -337,7 +337,7 @@ auth_requests:
 				upstream.Address = net.JoinHostPort(upstreamResp.Host, strconv.Itoa(int(upstreamResp.Port)))
 				// Report the backend the API picked, not the PROXY protocol
 				// hop that the address below may be rewritten to.
-				info.Upstream = upstream.Address
+				info.UpstreamHost, info.UpstreamPort = upstreamResp.Host, upstreamResp.Port
 				if resp.Proxy != nil {
 					proxyConfig := *resp.Proxy
 					// parse protocol version


### PR DESCRIPTION
This PR renames the metric attributes after the [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/), falling back to the [Elastic Common Schema](https://www.elastic.co/guide/en/ecs/current/index.html) and then to our own namespace:

```
username          ->  user.name                      (semconv)
upstream.address  ->  server.address, server.port    (semconv)
result            ->  event.outcome                  (ECS)
auth.method       ->  sshmux.auth.method
auth.status       ->  sshmux.auth.status
```

`error.type` was the only one already taken from a registry; the rest sat in generic namespaces that a future convention could claim.

Two configuration keys come with it. `metrics.convention` selects the order above or ECS alone, for deployments that would rather not be renamed again — the two currently name every attribute identically, and only diverge once the conventions move. `metrics.prometheus.translation-strategy` picks how those names are rendered for Prometheus, taking the same values as the collector's exporter.

Note that this renames labels shipped in https://github.com/USTC-vlab/sshmux/pull/30, so dashboards and alerts built on them need updating.

---

**Disclaimer:** This PR is drafted in heavy cooperation with [Claude Code](https://claude.com/product/claude-code), tested and reviewed.