### PR TITLE
Add distributed tracing support via OTLP

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,34 +96,9 @@ Settings left out of the TOML file fall back to the standard OpenTelemetry envir
 
 `OTEL_SDK_DISABLED` and `OTEL_METRICS_EXPORTER` are **not** used: `metrics.enabled` and the two `enabled` keys under it are the only switches that decide what runs.
 
-#### OTLP Settings
+#### Metrics OTLP Settings
 
-OTLP settings configure the OTLP push exporter. They are grouped under `metrics.otlp` in the TOML file.
-
-| Key               | Type           | Description                                                                                                                  | Required                      | Example                     |
-| ----------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------- | ----------------------------- | --------------------------- |
-| `enabled`         | `bool`         | Whether the OTLP exporter is enabled. Defaults to `false`.                                                                   | No                            | `true`                      |
-| `protocol`        | `string`       | OTLP transport to use, either `"http"` or `"grpc"`. Defaults to `"http"`.                                                    | No                            | `"grpc"`                    |
-| `endpoint`        | `string`       | Endpoint URL of the OTLP collector. Defaults to `https://localhost:4318/v1/metrics` for `http`, and `https://localhost:4317` for `grpc` | No                 | `"http://127.0.0.1:4318/v1/metrics"` |
-| `headers`         | `[]HTTPHeader` | Extra headers (gRPC metadata for `grpc`) to send to the collector, e.g. for authentication.                                  | No                            | See [`etc/config.example.toml`](etc/config.example.toml) |
-| `timeout-seconds` | `uint`         | Timeout for a single export request. Defaults to 10 seconds.                                                                 | No                            | `10`                        |
-
-`"http/protobuf"` is accepted as a synonym for `"http"`, since that is the spelling the OpenTelemetry specification uses for `OTEL_EXPORTER_OTLP_PROTOCOL`. The specification's third value, `"http/json"`, is not supported.
-
-For `http`, `endpoint` is a signal-specific endpoint and is used exactly as written, like `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`; only the generic `OTEL_EXPORTER_OTLP_ENDPOINT` is a base URL that `/v1/metrics` is appended to. Spell the path out: `"http://127.0.0.1:4318"` posts to the collector's root, and a gateway documented as `"https://otlp.example.com/otlp"` has to be configured as `"https://otlp.example.com/otlp/v1/metrics"`.
-
-A `grpc` `endpoint` must not carry a path.
-
-Each key above may be left out and supplied by an environment variable instead:
-
-| Key               | Environment variable                                                 |
-| ----------------- | -------------------------------------------------------------------- |
-| `protocol`        | `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL`, `OTEL_EXPORTER_OTLP_PROTOCOL` |
-| `endpoint`        | `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`, `OTEL_EXPORTER_OTLP_ENDPOINT` |
-| `headers`         | `OTEL_EXPORTER_OTLP_METRICS_HEADERS`, `OTEL_EXPORTER_OTLP_HEADERS`   |
-| `timeout-seconds` | `OTEL_EXPORTER_OTLP_METRICS_TIMEOUT`, `OTEL_EXPORTER_OTLP_TIMEOUT`   |
-
-Where two are listed, the signal-specific one takes precedence. The exporters read further variables that have no equivalent in the TOML file, such as `OTEL_EXPORTER_OTLP_COMPRESSION`, `OTEL_EXPORTER_OTLP_INSECURE` and the `OTEL_EXPORTER_OTLP_CERTIFICATE` family; those are always honoured.
+The OTLP exporter for metrics is configured under `metrics.otlp`, whose keys are described in [OTLP Settings](#otlp-settings). Metrics are exported to the `/v1/metrics` path, and read `OTEL_EXPORTER_OTLP_METRICS_*` for the settings left out of the file.
 
 #### Prometheus Settings
 
@@ -138,6 +113,54 @@ Prometheus settings configure the Prometheus scrape endpoint. They are grouped u
 
 See the [OpenTelemetry Collector's Prometheus exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/prometheusexporter/README.md) for what each translation strategy does.
 
+### Tracer Settings
+
+Tracer settings configure the [OpenTelemetry](https://opentelemetry.io) tracing of `sshmux`. They are grouped under `tracer` in the TOML file.
+
+| Key            | Type                      | Description                                                                                | Required | Example                              |
+| -------------- | ------------------------- | ------------------------------------------------------------------------------------------ | -------- | ------------------------------------ |
+| `enabled`      | `bool`                    | Whether tracing is enabled. Defaults to `false`.                                           | No       | `true`                               |
+| `convention`   | `string`                  | Schema the attributes are named after, `"default"` or `"ecs"`. Defaults to `"default"`. See [Attribute Conventions](#attribute-conventions). | No | `"ecs"` |
+| `service-name` | `string`                  | Value of the `service.name` resource attribute. Defaults to `"sshmux"`.                    | No       | `"sshmux-vlab"`                      |
+| `attributes`   | `[]ResourceAttribute`     | Extra resource attributes attached to every span.                                          | No       | `[{ name = "env", value = "prod" }]` |
+| `sample-ratio` | `float`                   | Fraction of traces to record, between 0 and 1. Defaults to recording every trace.          | No       | `0.25`                               |
+| `propagation`  | `bool`                    | Whether auth API requests carry trace context. Defaults to `true`.                         | No       | `false`                              |
+
+Settings left out of the TOML file fall back to the standard OpenTelemetry environment variables, so precedence is configuration file, then environment, then default. Here `service-name` and `attributes` fall back to `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES`, and `sample-ratio` to `OTEL_TRACES_SAMPLER` with `OTEL_TRACES_SAMPLER_ARG`.
+
+#### Tracer OTLP Settings
+
+The OTLP exporter for traces is configured under `tracer.otlp`, whose keys are described in [OTLP Settings](#otlp-settings). Spans are exported to the `/v1/traces` path, and read `OTEL_EXPORTER_OTLP_TRACES_*` for the settings left out of the file. Unlike metrics, there is no scrape endpoint: spans are only ever pushed.
+
+### OTLP Settings
+
+OTLP settings configure an OTLP push exporter. They are grouped per signal, under `metrics.otlp` and `tracer.otlp` in the TOML file.
+
+| Key               | Type           | Description                                                                                                                  | Required                      | Example                     |
+| ----------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------- | ----------------------------- | --------------------------- |
+| `enabled`         | `bool`         | Whether the OTLP exporter is enabled. Defaults to `false`.                                                                   | No                            | `true`                      |
+| `protocol`        | `string`       | OTLP transport to use, either `"http"` or `"grpc"`. Defaults to `"http"`.                                                    | No                            | `"grpc"`                    |
+| `endpoint`        | `string`       | Endpoint URL of the OTLP collector, used exactly as written. Defaults to `https://localhost:4318/v1/<signal>` for `http`, and `https://localhost:4317` for `grpc`. | No | `"http://127.0.0.1:4318/v1/metrics"` |
+| `headers`         | `[]HTTPHeader` | Extra headers (gRPC metadata for `grpc`) to send to the collector, e.g. for authentication.                                  | No                            | See [`etc/config.example.toml`](etc/config.example.toml) |
+| `timeout-seconds` | `uint`         | Timeout for a single export request. Defaults to 10 seconds.                                                                 | No                            | `10`                        |
+
+`"http/protobuf"` is accepted as a synonym for `"http"`, since that is the spelling the OpenTelemetry specification uses for `OTEL_EXPORTER_OTLP_PROTOCOL`. The specification's third value, `"http/json"`, is not supported.
+
+For `http`, `endpoint` is a signal-specific endpoint and is used exactly as written, like `OTEL_EXPORTER_OTLP_<SIGNAL>_ENDPOINT`; only the generic `OTEL_EXPORTER_OTLP_ENDPOINT` is a base URL that the signal path is appended to. Spell the path out: `"http://127.0.0.1:4318"` posts to the collector's root, and a gateway documented as `"https://otlp.example.com/otlp"` has to be configured as `"https://otlp.example.com/otlp/v1/metrics"`.
+
+A `grpc` `endpoint` must not carry a path.
+
+Each key above may be left out and supplied by an environment variable instead:
+
+| Key               | Environment variable                                                  |
+| ----------------- | --------------------------------------------------------------------- |
+| `protocol`        | `OTEL_EXPORTER_OTLP_<SIGNAL>_PROTOCOL`, `OTEL_EXPORTER_OTLP_PROTOCOL` |
+| `endpoint`        | `OTEL_EXPORTER_OTLP_<SIGNAL>_ENDPOINT`, `OTEL_EXPORTER_OTLP_ENDPOINT` |
+| `headers`         | `OTEL_EXPORTER_OTLP_<SIGNAL>_HEADERS`, `OTEL_EXPORTER_OTLP_HEADERS`   |
+| `timeout-seconds` | `OTEL_EXPORTER_OTLP_<SIGNAL>_TIMEOUT`, `OTEL_EXPORTER_OTLP_TIMEOUT`   |
+
+Where two are listed, the signal-specific one takes precedence. The exporters read further variables that have no equivalent in the TOML file, such as `OTEL_EXPORTER_OTLP_COMPRESSION`, `OTEL_EXPORTER_OTLP_INSECURE` and the `OTEL_EXPORTER_OTLP_CERTIFICATE` family; those are always honoured.
+
 ### PROXY Protocol Settings
 
 PROXY protocol settings configures [PROXY protocol](https://www.haproxy.com/blog/use-the-proxy-protocol-to-preserve-a-clients-ip-address) support in `sshmux`. They are grouped under `proxy-protocol` in the TOML file.
@@ -150,7 +173,7 @@ PROXY protocol settings configures [PROXY protocol](https://www.haproxy.com/blog
 
 ## Attribute Conventions
 
-`metrics.convention` selects how each attribute is named:
+`metrics.convention` and `tracer.convention` select how each attribute is named:
 
 | Value | Resolves each attribute against |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ See the [OpenTelemetry Collector's Prometheus exporter](https://github.com/open-
 
 ### Tracer Settings
 
-Tracer settings configure the [OpenTelemetry](https://opentelemetry.io) tracing of `sshmux`. They are grouped under `tracer` in the TOML file.
+Tracer settings configure the [OpenTelemetry](https://opentelemetry.io) tracing of `sshmux`, which is described under [Tracing](#tracing). They are grouped under `tracer` in the TOML file.
 
 | Key            | Type                      | Description                                                                                | Required | Example                              |
 | -------------- | ------------------------- | ------------------------------------------------------------------------------------------ | -------- | ------------------------------------ |
@@ -124,7 +124,7 @@ Tracer settings configure the [OpenTelemetry](https://opentelemetry.io) tracing 
 | `service-name` | `string`                  | Value of the `service.name` resource attribute. Defaults to `"sshmux"`.                    | No       | `"sshmux-vlab"`                      |
 | `attributes`   | `[]ResourceAttribute`     | Extra resource attributes attached to every span.                                          | No       | `[{ name = "env", value = "prod" }]` |
 | `sample-ratio` | `float`                   | Fraction of traces to record, between 0 and 1. Defaults to recording every trace.          | No       | `0.25`                               |
-| `propagation`  | `bool`                    | Whether auth API requests carry trace context. Defaults to `true`.                         | No       | `false`                              |
+| `propagation`  | `bool`                    | Whether auth API requests carry trace context. Defaults to `true`. See [Tracing](#tracing). | No      | `false`                              |
 
 Settings left out of the TOML file fall back to the standard OpenTelemetry environment variables, so precedence is configuration file, then environment, then default. Here `service-name` and `attributes` fall back to `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES`, and `sample-ratio` to `OTEL_TRACES_SAMPLER` with `OTEL_TRACES_SAMPLER_ARG`.
 
@@ -180,7 +180,12 @@ PROXY protocol settings configures [PROXY protocol](https://www.haproxy.com/blog
 | `default` | the [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/), then the [Elastic Common Schema](https://www.elastic.co/guide/en/ecs/current/index.html), then `sshmux` |
 | `ecs` | the [Elastic Common Schema](https://www.elastic.co/guide/en/ecs/current/index.html), then `sshmux` |
 
-They currently differ in no attribute.
+They differ in two attributes, one named apart and one that ECS has no field for:
+
+| Attribute            | `default`                  | `ecs`              |
+| -------------------- | -------------------------- | ------------------ |
+| Application protocol | `network.protocol.name`    | `network.protocol` |
+| Its version          | `network.protocol.version` | dropped            |
 
 ## Metrics
 
@@ -225,6 +230,27 @@ Setting `metrics.connection-grouping` to `false` drops both dimensions, leaving 
 > **Turn the grouping off once your user base approaches 2000.** Since users normally map one-to-one onto backends, the two dimensions together produce roughly one time series per user, and that count only ever grows, because the metrics are cumulative. The OpenTelemetry SDK caps each instrument at 2000 series by default: past the cap, measurements do not stop being recorded, but they collapse into a single series marked `otel.metric.overflow="true"`, and which users kept a series of their own comes down to whoever connected first after startup. Grouped metrics are therefore only meaningful below the cap.
 >
 > The `OTEL_GO_X_CARDINALITY_LIMIT` environment variable raises the cap if you would rather keep the grouping, at the cost of memory that grows with your user count. There is no TOML equivalent, because raising it is rarely the right answer.
+
+## Tracing
+
+`sshmux` records a span for each stage of a connection, which are turned on and pointed at a collector through the [Tracer Settings](#tracer-settings).
+
+| Span                    | Kind       | Parent                  | Attributes                                                   | Covers                                                    |
+| ----------------------- | ---------- | ----------------------- | ------------------------------------------------------------ | --------------------------------------------------------- |
+| `establish ssh session` | `server`   | —                       | Connection, peer                                             | Accepting the connection through to a session that is up. |
+| `ssh handshake`         | `internal` | `establish ssh session` | Connection                                                   | The downstream handshake and authentication.              |
+| `authenticate user`     | `client`   | `ssh handshake`         | `server.*`, peer, `sshmux.auth.method`, `sshmux.auth.status` | One request to the auth API.                              |
+| `connect upstream`      | `client`   | `ssh handshake`         | `server.*`, peer                                             | Dialling the backend.                                     |
+
+The connection attributes are `network.protocol.name`, `network.protocol.version`, `user.name`, `client.address`, `client.port`, `server.address` and `server.port`, naming the client that connected and the backend the auth API picked. Those are the logical ends, the ones behind any intermediary. A span's peer, `network.peer.address` and `network.peer.port`, is the address at the other end of the network connection the span itself covers, which its kind fixes — the client that reached `sshmux` for a server span, the service called for a client span, and neither for an internal one. It differs from the logical end where a PROXY protocol hop sits in between, and is missing only from a dial that never connected.
+
+The kinds are also what a collector builds a service graph from: `sshmux` serves the session, and calls the auth API and the backend on its behalf.
+
+The session span ends once the session is established, not when it closes: a session stays up for as long as the client is connected, and a span left open that long is never exported. How long a session lived is reported by `sshmux.session.duration` instead.
+
+An attribute is left off while its value is unknown, rather than recorded as `unknown` the way the metrics do. A span whose step failed records the error and is marked with an error status.
+
+Requests to the auth API carry the `authenticate user` span as a W3C `traceparent` header, so an auth server that is itself instrumented continues the same trace. Set `tracer.propagation` to `false` to stop sending it.
 
 ## Auth API
 

--- a/auth.go
+++ b/auth.go
@@ -61,7 +61,7 @@ type AuthProxy struct {
 }
 
 type Authenticator interface {
-	Auth(request AuthRequest, username string) (int, *AuthResponse, error)
+	Auth(ctx context.Context, request AuthRequest, username string) (int, *AuthResponse, error)
 }
 
 func makeAuthenticator(auth AuthConfig) (Authenticator, error) {
@@ -92,7 +92,7 @@ type RESTfulAuthenticator struct {
 	Client   *http.Client
 }
 
-func (auth *RESTfulAuthenticator) Auth(request AuthRequest, username string) (int, *AuthResponse, error) {
+func (auth *RESTfulAuthenticator) Auth(ctx context.Context, request AuthRequest, username string) (int, *AuthResponse, error) {
 	if auth.Version != "v1" {
 		return 500, nil, fmt.Errorf("unsupported API version: %s", auth.Version)
 	}
@@ -103,7 +103,7 @@ func (auth *RESTfulAuthenticator) Auth(request AuthRequest, username string) (in
 		return 0, nil, err
 	}
 
-	req, err := http.NewRequest("POST", auth_url, payload)
+	req, err := http.NewRequestWithContext(ctx, "POST", auth_url, payload)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -136,10 +136,10 @@ type instrumentedAuthenticator struct {
 	metrics *Metrics
 }
 
-func (a *instrumentedAuthenticator) Auth(request AuthRequest, username string) (int, *AuthResponse, error) {
+func (a *instrumentedAuthenticator) Auth(ctx context.Context, request AuthRequest, username string) (int, *AuthResponse, error) {
 	start := time.Now()
-	status, response, err := a.inner.Auth(request, username)
-	a.metrics.AuthFinished(context.Background(), request.Method, status, err, time.Since(start))
+	status, response, err := a.inner.Auth(ctx, request, username)
+	a.metrics.AuthFinished(ctx, request.Method, status, err, time.Since(start))
 	return status, response, err
 }
 

--- a/auth.go
+++ b/auth.go
@@ -105,7 +105,7 @@ func (auth *RESTfulAuthenticator) Auth(ctx context.Context, request AuthRequest,
 		return 0, nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", auth_url, payload)
+	req, err := http.NewRequestWithContext(auth.Tracer.tracePeer(ctx), "POST", auth_url, payload)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -137,11 +137,18 @@ func (auth *RESTfulAuthenticator) Auth(ctx context.Context, request AuthRequest,
 type instrumentedAuthenticator struct {
 	inner   Authenticator
 	metrics *Metrics
+	tracer  *Tracer
+	// server is the auth API the wrapped Authenticator calls.
+	server *url.URL
 }
 
 func (a *instrumentedAuthenticator) Auth(ctx context.Context, request AuthRequest, username string) (int, *AuthResponse, error) {
 	start := time.Now()
+	ctx, span := a.tracer.Start(ctx, "authenticate user", spanKindClient)
 	status, response, err := a.inner.Auth(ctx, request, username)
+	endSpan(span, err, append(a.tracer.serverAttributes(a.server),
+		a.tracer.attrs.sshmuxAuthMethod.String(request.Method),
+		a.tracer.attrs.sshmuxAuthStatus.Int(status))...)
 	a.metrics.AuthFinished(ctx, request.Method, status, err, time.Since(start))
 	return status, response, err
 }

--- a/auth.go
+++ b/auth.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -126,6 +127,20 @@ func (auth *RESTfulAuthenticator) Auth(request AuthRequest, username string) (in
 		return res.StatusCode, nil, err
 	}
 	return res.StatusCode, &response, nil
+}
+
+// instrumentedAuthenticator records the outcome and latency of every auth API
+// request made through the wrapped Authenticator.
+type instrumentedAuthenticator struct {
+	inner   Authenticator
+	metrics *Metrics
+}
+
+func (a *instrumentedAuthenticator) Auth(request AuthRequest, username string) (int, *AuthResponse, error) {
+	start := time.Now()
+	status, response, err := a.inner.Auth(request, username)
+	a.metrics.AuthFinished(context.Background(), request.Method, status, err, time.Since(start))
+	return status, response, err
 }
 
 func timeoutFromSeconds(seconds uint, defaultTimeout time.Duration) time.Duration {

--- a/auth.go
+++ b/auth.go
@@ -64,7 +64,7 @@ type Authenticator interface {
 	Auth(ctx context.Context, request AuthRequest, username string) (int, *AuthResponse, error)
 }
 
-func makeAuthenticator(auth AuthConfig) (Authenticator, error) {
+func makeAuthenticator(auth AuthConfig, tracer *Tracer) (Authenticator, error) {
 	if auth.Version == "" {
 		auth.Version = "v1"
 	}
@@ -81,6 +81,7 @@ func makeAuthenticator(auth AuthConfig) (Authenticator, error) {
 		Version:  auth.Version,
 		Headers:  headers,
 		Client:   &http.Client{Timeout: timeoutFromSeconds(auth.TimeoutSeconds, defaultAuthTimeout)},
+		Tracer:   tracer,
 	}
 	return &authenticator, nil
 }
@@ -90,6 +91,7 @@ type RESTfulAuthenticator struct {
 	Version  string
 	Headers  http.Header
 	Client   *http.Client
+	Tracer   *Tracer
 }
 
 func (auth *RESTfulAuthenticator) Auth(ctx context.Context, request AuthRequest, username string) (int, *AuthResponse, error) {
@@ -110,6 +112,7 @@ func (auth *RESTfulAuthenticator) Auth(ctx context.Context, request AuthRequest,
 	req.Header = auth.Headers.Clone()
 	req.Header.Set("accept", "application/json")
 	req.Header.Set("content-type", "application/json")
+	auth.Tracer.Inject(ctx, req.Header)
 
 	res, err := auth.Client.Do(req)
 	if err != nil {

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"io"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 )
@@ -36,5 +38,45 @@ func TestAuthenticatorTimeouts(t *testing.T) {
 	legacy := makeLegacyAuthenticator(AuthConfig{TimeoutSeconds: 11}, RecoveryConfig{})
 	if got := legacy.Client.Timeout; got != 11*time.Second {
 		t.Fatalf("legacy auth timeout = %s, want %s", got, 11*time.Second)
+	}
+}
+
+type stubAuthenticator struct {
+	status int
+	err    error
+}
+
+func (a *stubAuthenticator) Auth(AuthRequest, string) (int, *AuthResponse, error) {
+	return a.status, nil, a.err
+}
+
+func TestInstrumentedAuthenticator(t *testing.T) {
+	metrics := prometheusMetrics(t)
+	authenticator := &instrumentedAuthenticator{
+		inner:   &stubAuthenticator{status: 401},
+		metrics: metrics,
+	}
+	status, _, err := authenticator.Auth(AuthRequest{Method: "publickey"}, "vlab")
+	if err != nil || status != 401 {
+		t.Fatalf("Auth() = (%d, %v), want (401, nil)", status, err)
+	}
+
+	failing := &instrumentedAuthenticator{
+		inner:   &stubAuthenticator{err: io.ErrUnexpectedEOF},
+		metrics: metrics,
+	}
+	if _, _, err := failing.Auth(AuthRequest{Method: "keyboard-interactive"}, "vlab"); err == nil {
+		t.Fatal("Auth() error = nil, want an error")
+	}
+
+	body := scrape(t, metrics)
+	for _, want := range []string{
+		`sshmux_auth_requests_total{event_outcome="success",sshmux_auth_method="publickey",sshmux_auth_status="401"} 1`,
+		`sshmux_auth_requests_total{error_type="eof",event_outcome="failure",sshmux_auth_method="keyboard-interactive",sshmux_auth_status="0"} 1`,
+		`sshmux_auth_duration_seconds_count{event_outcome="success",sshmux_auth_method="publickey",sshmux_auth_status="401"} 1`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("scrape output does not contain %q:\n%s", want, body)
+		}
 	}
 }

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"io"
 	"net/url"
 	"strings"
@@ -46,7 +47,7 @@ type stubAuthenticator struct {
 	err    error
 }
 
-func (a *stubAuthenticator) Auth(AuthRequest, string) (int, *AuthResponse, error) {
+func (a *stubAuthenticator) Auth(context.Context, AuthRequest, string) (int, *AuthResponse, error) {
 	return a.status, nil, a.err
 }
 
@@ -56,7 +57,7 @@ func TestInstrumentedAuthenticator(t *testing.T) {
 		inner:   &stubAuthenticator{status: 401},
 		metrics: metrics,
 	}
-	status, _, err := authenticator.Auth(AuthRequest{Method: "publickey"}, "vlab")
+	status, _, err := authenticator.Auth(t.Context(), AuthRequest{Method: "publickey"}, "vlab")
 	if err != nil || status != 401 {
 		t.Fatalf("Auth() = (%d, %v), want (401, nil)", status, err)
 	}
@@ -65,7 +66,7 @@ func TestInstrumentedAuthenticator(t *testing.T) {
 		inner:   &stubAuthenticator{err: io.ErrUnexpectedEOF},
 		metrics: metrics,
 	}
-	if _, _, err := failing.Auth(AuthRequest{Method: "keyboard-interactive"}, "vlab"); err == nil {
+	if _, _, err := failing.Auth(t.Context(), AuthRequest{Method: "keyboard-interactive"}, "vlab"); err == nil {
 		t.Fatal("Auth() error = nil, want an error")
 	}
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -28,7 +28,7 @@ func TestAuthenticatorTimeouts(t *testing.T) {
 		Endpoint:       endpoint.String(),
 		Version:        "v1",
 		TimeoutSeconds: 7,
-	})
+	}, noopTracer())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,7 +36,7 @@ func TestAuthenticatorTimeouts(t *testing.T) {
 		t.Fatalf("REST auth timeout = %s, want %s", got, 7*time.Second)
 	}
 
-	legacy := makeLegacyAuthenticator(AuthConfig{TimeoutSeconds: 11}, RecoveryConfig{})
+	legacy := makeLegacyAuthenticator(AuthConfig{TimeoutSeconds: 11}, RecoveryConfig{}, noopTracer())
 	if got := legacy.Client.Timeout; got != 11*time.Second {
 		t.Fatalf("legacy auth timeout = %s, want %s", got, 11*time.Second)
 	}

--- a/auth_test.go
+++ b/auth_test.go
@@ -56,6 +56,7 @@ func TestInstrumentedAuthenticator(t *testing.T) {
 	authenticator := &instrumentedAuthenticator{
 		inner:   &stubAuthenticator{status: 401},
 		metrics: metrics,
+		tracer:  noopTracer(),
 	}
 	status, _, err := authenticator.Auth(t.Context(), AuthRequest{Method: "publickey"}, "vlab")
 	if err != nil || status != 401 {
@@ -65,6 +66,7 @@ func TestInstrumentedAuthenticator(t *testing.T) {
 	failing := &instrumentedAuthenticator{
 		inner:   &stubAuthenticator{err: io.ErrUnexpectedEOF},
 		metrics: metrics,
+		tracer:  noopTracer(),
 	}
 	if _, _, err := failing.Auth(t.Context(), AuthRequest{Method: "keyboard-interactive"}, "vlab"); err == nil {
 		t.Fatal("Auth() error = nil, want an error")

--- a/config.go
+++ b/config.go
@@ -54,22 +54,22 @@ type RecoveryConfig struct {
 }
 
 type MetricsConfig struct {
-	Enabled            bool                     `toml:"enabled"`
-	Convention         MetricsConvention        `toml:"convention,omitempty"`
-	ServiceName        string                   `toml:"service-name,omitempty"`
-	Attributes         []MetricsAttributeConfig `toml:"attributes,omitempty"`
-	IntervalSeconds    uint                     `toml:"interval-seconds,omitempty"`
-	ConnectionGrouping *bool                    `toml:"connection-grouping,omitempty"`
-	OTLP               MetricsOTLPConfig        `toml:"otlp"`
-	Prometheus         MetricsPrometheusConfig  `toml:"prometheus"`
+	Enabled            bool                      `toml:"enabled"`
+	Convention         AttributeConvention       `toml:"convention,omitempty"`
+	ServiceName        string                    `toml:"service-name,omitempty"`
+	Attributes         []ResourceAttributeConfig `toml:"attributes,omitempty"`
+	IntervalSeconds    uint                      `toml:"interval-seconds,omitempty"`
+	ConnectionGrouping *bool                     `toml:"connection-grouping,omitempty"`
+	OTLP               OTLPConfig                `toml:"otlp"`
+	Prometheus         MetricsPrometheusConfig   `toml:"prometheus"`
 }
 
-type MetricsAttributeConfig struct {
+type ResourceAttributeConfig struct {
 	Name  string `toml:"name"`
 	Value string `toml:"value"`
 }
 
-type MetricsOTLPConfig struct {
+type OTLPConfig struct {
 	Enabled        bool               `toml:"enabled"`
 	Protocol       string             `toml:"protocol,omitempty"`
 	Endpoint       string             `toml:"endpoint"`
@@ -112,27 +112,28 @@ type LegacyConfig struct {
 	InvalidUsernameMessage string   `json:"invalid-username-message"`
 }
 
-// MetricsConvention names the schema the metric attributes follow.
-type MetricsConvention string
+// AttributeConvention names the schema the data point and span attributes
+// follow. It does not affect the resource attributes.
+type AttributeConvention string
 
 const (
-	// MetricsConventionDefault resolves each attribute against the
+	// AttributeConventionDefault resolves each attribute against the
 	// OpenTelemetry semantic conventions, then the Elastic Common Schema, then
 	// sshmux's own namespace, and follows the conventions wherever they move.
-	MetricsConventionDefault MetricsConvention = "default"
-	// MetricsConventionECS resolves against the Elastic Common Schema only,
+	AttributeConventionDefault AttributeConvention = "default"
+	// AttributeConventionECS resolves against the Elastic Common Schema only,
 	// which does not move.
-	MetricsConventionECS MetricsConvention = "ecs"
+	AttributeConventionECS AttributeConvention = "ecs"
 )
 
-func (c *MetricsConvention) UnmarshalText(text []byte) error {
-	switch value := MetricsConvention(text); value {
-	case "", MetricsConventionDefault, MetricsConventionECS:
+func (c *AttributeConvention) UnmarshalText(text []byte) error {
+	switch value := AttributeConvention(text); value {
+	case "", AttributeConventionDefault, AttributeConventionECS:
 		*c = value
 		return nil
 	default:
 		return fmt.Errorf("unsupported metrics convention %q, want %q or %q",
-			value, MetricsConventionDefault, MetricsConventionECS)
+			value, AttributeConventionDefault, AttributeConventionECS)
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -84,12 +84,23 @@ type MetricsPrometheusConfig struct {
 	TranslationStrategy PrometheusTranslationStrategy `toml:"translation-strategy,omitempty"`
 }
 
+type TracerConfig struct {
+	Enabled     bool                      `toml:"enabled"`
+	Convention  AttributeConvention       `toml:"convention,omitempty"`
+	ServiceName string                    `toml:"service-name,omitempty"`
+	Attributes  []ResourceAttributeConfig `toml:"attributes,omitempty"`
+	SampleRatio *float64                  `toml:"sample-ratio,omitempty"`
+	Propagation *bool                     `toml:"propagation,omitempty"`
+	OTLP        OTLPConfig                `toml:"otlp"`
+}
+
 type Config struct {
 	Address       string              `toml:"address"`
 	SSH           SSHConfig           `toml:"ssh"`
 	Auth          AuthConfig          `toml:"auth"`
 	Logger        LoggerConfig        `toml:"logger"`
 	Metrics       MetricsConfig       `toml:"metrics"`
+	Tracer        TracerConfig        `toml:"tracer"`
 	ProxyProtocol ProxyProtocolConfig `toml:"proxy-protocol"`
 	Recovery      RecoveryConfig      `toml:"recovery"`
 }

--- a/config_test.go
+++ b/config_test.go
@@ -248,7 +248,7 @@ func TestConvertProxyPolicyConfig(t *testing.T) {
 // declares as types: that a good value decodes, that a bad one is refused
 // while parsing rather than later, and that every accepted value resolves.
 func TestEnumeratedMetricsKeys(t *testing.T) {
-	conventions := []MetricsConvention{MetricsConventionDefault, MetricsConventionECS}
+	conventions := []AttributeConvention{AttributeConventionDefault, AttributeConventionECS}
 	strategies := []PrometheusTranslationStrategy{UnderscoreEscaping, NoUTF8Escaping, NoTranslation}
 
 	for _, convention := range conventions {

--- a/config_test.go
+++ b/config_test.go
@@ -20,6 +20,7 @@ var configFixtures = []configFixture{
 	{"fixtures/legacy.toml", checkLegacyTOML},
 	{"fixtures/config.json", checkLegacyJSON},
 	{"fixtures/metrics.toml", checkMetricsTOML},
+	{"fixtures/tracer.toml", checkTracerTOML},
 }
 
 func TestLoadConfigFixtures(t *testing.T) {
@@ -29,7 +30,7 @@ func TestLoadConfigFixtures(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if fixture.path == "fixtures/metrics.toml" {
+			if fixture.path == "fixtures/metrics.toml" || fixture.path == "fixtures/tracer.toml" {
 				fixture.check(t, config)
 				return
 			}
@@ -183,6 +184,52 @@ func checkMetricsTOML(t *testing.T, config Config) {
 	}
 	if metrics.ConnectionGrouping == nil || *metrics.ConnectionGrouping {
 		t.Errorf("metrics.connection-grouping = %v, want an explicit false", metrics.ConnectionGrouping)
+	}
+}
+
+// checkTracerTOML covers every key of the tracer group.
+func checkTracerTOML(t *testing.T, config Config) {
+	tracer := config.Tracer
+	if !tracer.Enabled || tracer.Convention != AttributeConventionECS {
+		t.Errorf("tracer = %+v", tracer)
+	}
+	if tracer.ServiceName != "sshmux-fixture" {
+		t.Errorf("tracer.service-name = %q", tracer.ServiceName)
+	}
+	if len(tracer.Attributes) != 1 || tracer.Attributes[0].Name != "deployment.environment.name" {
+		t.Errorf("tracer.attributes = %+v", tracer.Attributes)
+	}
+	if tracer.SampleRatio == nil || *tracer.SampleRatio != 0.25 {
+		t.Errorf("tracer.sample-ratio = %v, want 0.25", tracer.SampleRatio)
+	}
+	if tracer.Propagation == nil || *tracer.Propagation {
+		t.Errorf("tracer.propagation = %v, want an explicit false", tracer.Propagation)
+	}
+
+	otlp := tracer.OTLP
+	if !otlp.Enabled || otlp.Protocol != "grpc" || otlp.Endpoint != "http://127.0.0.1:4317" {
+		t.Errorf("tracer.otlp = %+v", otlp)
+	}
+	if otlp.TimeoutSeconds != 5 || len(otlp.Headers) != 1 {
+		t.Errorf("tracer.otlp = %+v", otlp)
+	}
+}
+
+// TestTracerConfigAbsent checks that a configuration without a tracer group
+// leaves it off, with both tri-state keys unset.
+func TestTracerConfigAbsent(t *testing.T) {
+	config, err := loadConfig("fixtures/config.toml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Tracer.Enabled || config.Tracer.OTLP.Enabled {
+		t.Errorf("tracer = %+v, want it disabled", config.Tracer)
+	}
+	if config.Tracer.SampleRatio != nil || config.Tracer.Propagation != nil {
+		t.Errorf("tracer tri-state keys = %v, %v, want both nil", config.Tracer.SampleRatio, config.Tracer.Propagation)
+	}
+	if !boolOrDefault(config.Tracer.Propagation, true) {
+		t.Error("an absent propagation must leave it enabled")
 	}
 }
 

--- a/etc/config.example.toml
+++ b/etc/config.example.toml
@@ -48,6 +48,17 @@ enabled = true
 address = "127.0.0.1:9100"
 path = "/metrics"
 
+[tracer]
+enabled = true
+service-name = "sshmux"
+sample-ratio = 0.25
+propagation = true
+
+[tracer.otlp]
+enabled = true
+protocol = "grpc"
+endpoint = "http://127.0.0.1:4317"
+
 [proxy-protocol]
 enabled = true
 hosts = ["127.0.0.22"]

--- a/fixtures/tracer.toml
+++ b/fixtures/tracer.toml
@@ -1,0 +1,27 @@
+address = "0.0.0.0:8022"
+
+[ssh]
+host-keys = [{ path = "fixtures/ssh_host_ed25519_key" }]
+
+[auth]
+endpoint = "http://127.0.0.1:5000"
+version = "v1"
+
+[tracer]
+enabled = true
+convention = "ecs"
+service-name = "sshmux-fixture"
+attributes = [
+    { name = "deployment.environment.name", value = "staging" },
+]
+sample-ratio = 0.25
+propagation = false
+
+[tracer.otlp]
+enabled = true
+protocol = "grpc"
+endpoint = "http://127.0.0.1:4317"
+timeout-seconds = 5
+headers = [
+    { name = "Authorization", value = "ApiKey 12345678" },
+]

--- a/go.mod
+++ b/go.mod
@@ -17,10 +17,14 @@ require (
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.45.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.45.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.45.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.67.0
 	go.opentelemetry.io/otel/metric v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0
 	go.opentelemetry.io/otel/sdk/metric v1.45.0
+	go.opentelemetry.io/otel/trace v1.45.0
 )
 
 require (
@@ -36,7 +40,6 @@ require (
 	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/trace v1.45.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.11.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,8 @@ require (
 	go.opentelemetry.io/otel/sdk v1.45.0
 	go.opentelemetry.io/otel/sdk/metric v1.45.0
 	go.opentelemetry.io/otel/trace v1.45.0
+	go.opentelemetry.io/proto/otlp v1.11.0
+	google.golang.org/protobuf v1.36.11
 )
 
 require (
@@ -40,14 +42,12 @@ require (
 	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/proto/otlp v1.11.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260803160001-6ac0973c030d // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260803160001-6ac0973c030d // indirect
 	google.golang.org/grpc v1.83.0 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 )
 
 replace golang.org/x/crypto => ./crypto

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,12 @@ go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.45.0 h1:klT
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.45.0/go.mod h1:jRsK04CWmXuY8A0O+wMpSf+t90RHZ53o5Qmxn2PQPfk=
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.45.0 h1:pnxy6c/kvNBWdNNFzqpjuJLm9Hjhgk/Q0nY221rwuk0=
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.45.0/go.mod h1:qw6YsFapotRwoDhXRZvljzaOvCQB7UfnafEJagpN2TA=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 h1:QRefszxJmfPdjXUUm3j6iDzY03mTPXMjqErFqQ67vUg=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0/go.mod h1:Tiz03lTBVBrm7eWZBOidzEaYaJa8tjwGUGv6d8mlTyk=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 h1:fG5MCxGz8+2VtrN/WgqSpJFctVz24gpxj8CxkKmc8Ww=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0/go.mod h1:BmAYTn+3ysbRe+IU2msxmf5Rx3g6DHvex+tWI3LdhYI=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.45.0 h1:QBajQ2SrwQijzHyZbQlPsuIzpl/ll8DY6wPWsajeGcI=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.45.0/go.mod h1:08ZQLjrPLQ6R4kAXvuOvODEer5Yh4CoFvll5qB2BCI8=
 go.opentelemetry.io/otel/exporters/prometheus v0.67.0 h1:7IefDa35e6V3NoiqIeLDMDxMFyZDk5qcoC0Ax4cC16E=
 go.opentelemetry.io/otel/exporters/prometheus v0.67.0/go.mod h1:nsPI1awTg5Vmg1YrommL2mVarVGlqc4yXOoKAkPRD0c=
 go.opentelemetry.io/otel/metric v1.45.0 h1:7Eg1uH7CJ5cXv9is6tnBe1FI6rj1nwUdbFypRm3br/M=

--- a/legacy_auth.go
+++ b/legacy_auth.go
@@ -54,10 +54,11 @@ type LegacyAuthenticator struct {
 	UsernamePolicy UsernamePolicyConfig
 	PasswordPolicy PasswordPolicyConfig
 	Client         *http.Client
+	Tracer         *Tracer
 	Headers        http.Header
 }
 
-func makeLegacyAuthenticator(auth AuthConfig, recovery RecoveryConfig) LegacyAuthenticator {
+func makeLegacyAuthenticator(auth AuthConfig, recovery RecoveryConfig, tracer *Tracer) LegacyAuthenticator {
 	headers := http.Header{}
 	for _, header := range auth.Headers {
 		headers.Add(header.Name, header.Value)
@@ -76,6 +77,7 @@ func makeLegacyAuthenticator(auth AuthConfig, recovery RecoveryConfig) LegacyAut
 		},
 		Client:  &http.Client{Timeout: timeoutFromSeconds(auth.TimeoutSeconds, defaultAuthTimeout)},
 		Headers: headers,
+		Tracer:  tracer,
 	}
 }
 
@@ -170,6 +172,7 @@ func (auth LegacyAuthenticator) AuthUser(ctx context.Context, request any, usern
 	req.Header = auth.Headers.Clone()
 	req.Header.Set("accept", "application/json")
 	req.Header.Set("content-type", "application/json")
+	auth.Tracer.Inject(ctx, req.Header)
 	res, err := auth.Client.Do(req)
 	if err != nil {
 		return nil, err

--- a/legacy_auth.go
+++ b/legacy_auth.go
@@ -165,7 +165,7 @@ func (auth LegacyAuthenticator) AuthUser(ctx context.Context, request any, usern
 	if err := json.NewEncoder(payload).Encode(request); err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequestWithContext(ctx, "POST", auth.Endpoint, payload)
+	req, err := http.NewRequestWithContext(auth.Tracer.tracePeer(ctx), "POST", auth.Endpoint, payload)
 	if err != nil {
 		return nil, err
 	}

--- a/legacy_auth.go
+++ b/legacy_auth.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -78,7 +79,7 @@ func makeLegacyAuthenticator(auth AuthConfig, recovery RecoveryConfig) LegacyAut
 	}
 }
 
-func (auth *LegacyAuthenticator) Auth(request AuthRequest, username string) (int, *AuthResponse, error) {
+func (auth *LegacyAuthenticator) Auth(ctx context.Context, request AuthRequest, username string) (int, *AuthResponse, error) {
 	var upstream *LegacyAuthUpstream
 	var err error
 	if slices.Contains(auth.UsernamePolicy.InvalidUsernames, username) {
@@ -92,7 +93,7 @@ func (auth *LegacyAuthenticator) Auth(request AuthRequest, username string) (int
 		if err != nil {
 			return 500, nil, err
 		}
-		upstream, err = auth.AuthUserWithPublicKey(publicKey, username)
+		upstream, err = auth.AuthUserWithPublicKey(ctx, publicKey, username)
 		if err != nil {
 			return 500, nil, err
 		}
@@ -125,7 +126,7 @@ func (auth *LegacyAuthenticator) Auth(request AuthRequest, username string) (int
 			resp := AuthResponse{Challenges: []AuthChallenge{challenge}}
 			return 401, &resp, nil
 		}
-		upstream, err = auth.AuthUserWithUserPass(vlabUsername, vlabPassword, username)
+		upstream, err = auth.AuthUserWithUserPass(ctx, vlabUsername, vlabPassword, username)
 		if err != nil {
 			return 500, nil, err
 		}
@@ -157,12 +158,12 @@ func (auth *LegacyAuthenticator) Auth(request AuthRequest, username string) (int
 	return 403, &AuthResponse{}, nil
 }
 
-func (auth LegacyAuthenticator) AuthUser(request any, username string) (*LegacyAuthUpstream, error) {
+func (auth LegacyAuthenticator) AuthUser(ctx context.Context, request any, username string) (*LegacyAuthUpstream, error) {
 	payload := new(bytes.Buffer)
 	if err := json.NewEncoder(payload).Encode(request); err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest("POST", auth.Endpoint, payload)
+	req, err := http.NewRequestWithContext(ctx, "POST", auth.Endpoint, payload)
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +201,7 @@ func (auth LegacyAuthenticator) AuthUser(request any, username string) (*LegacyA
 	return &upstream, nil
 }
 
-func (auth LegacyAuthenticator) AuthUserWithPublicKey(key ssh.PublicKey, unixUsername string) (*LegacyAuthUpstream, error) {
+func (auth LegacyAuthenticator) AuthUserWithPublicKey(ctx context.Context, key ssh.PublicKey, unixUsername string) (*LegacyAuthUpstream, error) {
 	keyType := key.Type()
 	keyData := base64.StdEncoding.EncodeToString(key.Marshal())
 	request := &LegacyAuthRequestPublicKey{
@@ -210,10 +211,10 @@ func (auth LegacyAuthenticator) AuthUserWithPublicKey(key ssh.PublicKey, unixUse
 		PublicKeyData: keyData,
 		Token:         auth.Token,
 	}
-	return auth.AuthUser(request, unixUsername)
+	return auth.AuthUser(ctx, request, unixUsername)
 }
 
-func (auth LegacyAuthenticator) AuthUserWithUserPass(username string, password string, unixUsername string) (*LegacyAuthUpstream, error) {
+func (auth LegacyAuthenticator) AuthUserWithUserPass(ctx context.Context, username string, password string, unixUsername string) (*LegacyAuthUpstream, error) {
 	request := &LegacyAuthRequestPassword{
 		AuthType:     "key",
 		Username:     username,
@@ -221,5 +222,5 @@ func (auth LegacyAuthenticator) AuthUserWithUserPass(username string, password s
 		UnixUsername: unixUsername,
 		Token:        auth.Token,
 	}
-	return auth.AuthUser(request, unixUsername)
+	return auth.AuthUser(ctx, request, unixUsername)
 }

--- a/metrics.go
+++ b/metrics.go
@@ -8,9 +8,7 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
-	"runtime/debug"
 	"strings"
 	"time"
 
@@ -25,96 +23,12 @@ import (
 	"go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.43.0"
 )
 
 const (
-	defaultMetricsServiceName = "sshmux"
-	defaultPrometheusAddress  = "127.0.0.1:9100"
-	defaultPrometheusPath     = "/metrics"
-	metricsShutdownTimeout    = 5 * time.Second
-	metricsScopeName          = "github.com/USTC-vlab/sshmux"
-	// unknownAttributeValue is recorded for a grouping attribute whose value is
-	// not known, e.g. the username of a connection that failed before auth.
-	unknownAttributeValue = "unknown"
+	defaultPrometheusAddress = "127.0.0.1:9100"
+	defaultPrometheusPath    = "/metrics"
 )
-
-const (
-	envOTLPProtocol        = "OTEL_EXPORTER_OTLP_PROTOCOL"
-	envOTLPMetricsProtocol = "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"
-)
-
-// attributeNames is the set of attribute keys one convention resolves to.
-// Only the names differ between conventions; the values never do.
-type attributeNames struct {
-	result        attribute.Key
-	errorType     attribute.Key
-	userName      attribute.Key
-	serverAddress attribute.Key
-	serverPort    attribute.Key
-	authMethod    attribute.Key
-	authStatus    attribute.Key
-}
-
-// defaultAttributeNames resolves each attribute against the OpenTelemetry
-// semantic conventions first, then the Elastic Common Schema, then sshmux's
-// own namespace, and follows the conventions wherever they move.
-var defaultAttributeNames = attributeNames{
-	errorType:     attribute.Key("error.type"),     // semconv
-	userName:      attribute.Key("user.name"),      // semconv
-	serverAddress: attribute.Key("server.address"), // semconv
-	serverPort:    attribute.Key("server.port"),    // semconv
-	result:        attribute.Key("event.outcome"),  // ECS; semconv has no equivalent
-	authMethod:    attribute.Key("sshmux.auth.method"),
-	authStatus:    attribute.Key("sshmux.auth.status"),
-}
-
-// ecsAttributeNames resolves against the Elastic Common Schema only, which does
-// not move when the semantic conventions do.
-//
-// It currently names every attribute identically to defaultAttributeNames,
-// because the conventions adopted these fields from ECS. The two are kept
-// apart so that they can diverge without the configuration changing shape.
-var ecsAttributeNames = attributeNames{
-	errorType:     attribute.Key("error.type"),
-	userName:      attribute.Key("user.name"),
-	serverAddress: attribute.Key("server.address"),
-	serverPort:    attribute.Key("server.port"),
-	result:        attribute.Key("event.outcome"),
-	authMethod:    attribute.Key("sshmux.auth.method"),
-	authStatus:    attribute.Key("sshmux.auth.status"),
-}
-
-// conventionAttributeNames resolves the configured convention.
-func conventionAttributeNames(convention MetricsConvention) (attributeNames, error) {
-	switch convention {
-	case "", MetricsConventionDefault:
-		return defaultAttributeNames, nil
-	case MetricsConventionECS:
-		return ecsAttributeNames, nil
-	default:
-		// Unreachable: validateMetricsConfig accepts only the names above.
-		return attributeNames{}, fmt.Errorf("unsupported convention: %s", convention)
-	}
-}
-
-func (n attributeNames) success() attribute.KeyValue { return n.result.String("success") }
-func (n attributeNames) failure() attribute.KeyValue { return n.result.String("failure") }
-
-// connectionInfo is the per-connection state reported to the metrics recorder.
-// Fields are zero until they become known: Username is only set once the client
-// has sent its first auth request, and the upstream only once the auth API has
-// answered.
-type connectionInfo struct {
-	Username string
-	// UpstreamHost and UpstreamPort are the backend the auth API returned,
-	// before any PROXY protocol override.
-	UpstreamHost string
-	UpstreamPort uint16
-	// Established records whether the handshake completed.
-	Established bool
-}
 
 // Metrics owns the OpenTelemetry meter provider of an sshmux server, the
 // instruments recorded by it, and the optional Prometheus scrape endpoint.
@@ -155,7 +69,7 @@ func makeMetrics(config MetricsConfig) (*Metrics, error) {
 		attrs:            names,
 	}
 	if !config.Enabled {
-		return newMetrics(metrics, noop.NewMeterProvider().Meter(metricsScopeName))
+		return newMetrics(metrics, noop.NewMeterProvider().Meter(otelScopeName))
 	}
 	if !config.OTLP.Enabled && !config.Prometheus.Enabled {
 		return nil, errors.New("metrics are enabled but no exporter is configured")
@@ -163,7 +77,7 @@ func makeMetrics(config MetricsConfig) (*Metrics, error) {
 
 	readers := make([]sdkmetric.Reader, 0, 2)
 	if config.OTLP.Enabled {
-		exporter, err := makeOTLPExporter(config.OTLP)
+		exporter, err := makeOTLPMetricExporter(config.OTLP)
 		if err != nil {
 			return nil, err
 		}
@@ -202,7 +116,7 @@ func makeMetrics(config MetricsConfig) (*Metrics, error) {
 		metrics.promHandler = mux
 	}
 
-	res, err := makeMetricsResource(config)
+	res, err := otelResource(config.ServiceName, config.Attributes)
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +128,7 @@ func makeMetrics(config MetricsConfig) (*Metrics, error) {
 		options = append(options, sdkmetric.WithReader(reader))
 	}
 	metrics.provider = sdkmetric.NewMeterProvider(options...)
-	return newMetrics(metrics, metrics.provider.Meter(metricsScopeName))
+	return newMetrics(metrics, metrics.provider.Meter(otelScopeName))
 }
 
 // prometheusTranslationStrategy resolves how OTLP names are rendered for
@@ -248,7 +162,7 @@ func durationViews() []sdkmetric.View {
 	longBuckets := []float64{1, 5, 15, 30, 60, 300, 900, 1800, 3600, 7200, 21600, 86400}
 	view := func(name string, buckets []float64) sdkmetric.View {
 		return sdkmetric.NewView(
-			sdkmetric.Instrument{Name: name, Scope: instrumentation.Scope{Name: metricsScopeName}},
+			sdkmetric.Instrument{Name: name, Scope: instrumentation.Scope{Name: otelScopeName}},
 			sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
 				Boundaries: buckets,
 				NoMinMax:   false,
@@ -262,123 +176,27 @@ func durationViews() []sdkmetric.View {
 	}
 }
 
-func makeMetricsResource(config MetricsConfig) (*resource.Resource, error) {
-	// resource.Default reads OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES.
-	base := resource.Default()
-	attrs, err := metricsResourceAttributes(config, base)
+func makeOTLPMetricExporter(config OTLPConfig) (sdkmetric.Exporter, error) {
+	protocol, err := otlpProtocol(config.Protocol, envOTLPMetricsProtocol)
 	if err != nil {
 		return nil, err
 	}
-	// The base resource and our attributes share the same semantic convention
-	// schema, so the merge below never conflicts. Attributes from the second
-	// resource win, which is why only the ones the environment did not already
-	// provide are added.
-	res, err := resource.Merge(base, resource.NewWithAttributes(semconv.SchemaURL, attrs...))
-	if err != nil {
-		return nil, fmt.Errorf("failed to build metrics resource: %w", err)
-	}
-	return res, nil
-}
-
-// metricsResourceAttributes returns the resource attributes to layer on top of
-// base, honouring the config file over the environment over sshmux's defaults.
-func metricsResourceAttributes(config MetricsConfig, base *resource.Resource) ([]attribute.KeyValue, error) {
-	var attrs []attribute.KeyValue
-	// resource.Default only reports an `unknown_service:...` name when neither
-	// OTEL_SERVICE_NAME nor OTEL_RESOURCE_ATTRIBUTES supplied one.
-	if config.ServiceName != "" {
-		attrs = append(attrs, semconv.ServiceName(config.ServiceName))
-	} else if name, ok := resourceAttribute(base, semconv.ServiceNameKey); !ok || strings.HasPrefix(name, "unknown_service") {
-		attrs = append(attrs, semconv.ServiceName(defaultMetricsServiceName))
-	}
-	if _, ok := resourceAttribute(base, semconv.ServiceVersionKey); !ok {
-		attrs = append(attrs, semconv.ServiceVersion(buildVersion()))
-	}
-	if _, ok := resourceAttribute(base, semconv.HostNameKey); !ok {
-		if hostname, err := os.Hostname(); err == nil && hostname != "" {
-			attrs = append(attrs, semconv.HostName(hostname))
-		}
-	}
-	for _, attr := range config.Attributes {
-		if attr.Name == "" {
-			return nil, errors.New("metrics resource attributes must have a name")
-		}
-		attrs = append(attrs, attribute.String(attr.Name, attr.Value))
-	}
-	return attrs, nil
-}
-
-func resourceAttribute(res *resource.Resource, key attribute.Key) (string, bool) {
-	if res == nil {
-		return "", false
-	}
-	for _, attr := range res.Attributes() {
-		if attr.Key == key {
-			return attr.Value.AsString(), true
-		}
-	}
-	return "", false
-}
-
-// otlpProtocol resolves the OTLP transport, honouring the config file over
-// OTEL_EXPORTER_OTLP_METRICS_PROTOCOL over OTEL_EXPORTER_OTLP_PROTOCOL. Unlike
-// the endpoint and the headers, the protocol selects which exporter package is
-// used, so it cannot be delegated to the exporter itself.
-func otlpProtocol(configured string) (string, error) {
-	protocol := configured
-	for _, key := range []string{envOTLPMetricsProtocol, envOTLPProtocol} {
-		if protocol != "" {
-			break
-		}
-		protocol = strings.TrimSpace(os.Getenv(key))
-	}
-	switch protocol {
-	case "", "http", "http/protobuf":
-		return "http/protobuf", nil
-	case "grpc":
-		return "grpc", nil
-	default:
-		return "", fmt.Errorf("unsupported OTLP protocol: %s", protocol)
-	}
-}
-
-func makeOTLPExporter(config MetricsOTLPConfig) (sdkmetric.Exporter, error) {
-	protocol, err := otlpProtocol(config.Protocol)
+	endpoint, err := otlpEndpoint(config, protocol)
 	if err != nil {
 		return nil, err
 	}
-	// An unset endpoint defers to OTEL_EXPORTER_OTLP_[METRICS_]ENDPOINT, and in
-	// turn to the OTLP default of localhost:4317 or localhost:4318.
-	var endpoint *url.URL
-	if config.Endpoint != "" {
-		endpoint, err = url.Parse(config.Endpoint)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse OTLP endpoint: %w", err)
-		}
-		switch endpoint.Scheme {
-		case "http", "https":
-		default:
-			return nil, fmt.Errorf("unsupported OTLP endpoint scheme: %s", endpoint.Scheme)
-		}
-	}
-	headers := make(map[string]string, len(config.Headers))
-	for _, header := range config.Headers {
-		headers[header.Name] = header.Value
-	}
+	headers := otlpHeaders(config)
 
 	if protocol == "grpc" {
 		var options []otlpmetricgrpc.Option
 		if endpoint != nil {
-			if path := strings.Trim(endpoint.Path, "/"); path != "" {
-				return nil, fmt.Errorf("gRPC OTLP endpoint must not have a path: %s", config.Endpoint)
-			}
 			options = append(options, otlpmetricgrpc.WithEndpointURL(endpoint.String()))
 		}
 		if len(headers) > 0 {
 			options = append(options, otlpmetricgrpc.WithHeaders(headers))
 		}
-		if config.TimeoutSeconds != 0 {
-			options = append(options, otlpmetricgrpc.WithTimeout(time.Duration(config.TimeoutSeconds)*time.Second))
+		if timeout, ok := otlpTimeout(config); ok {
+			options = append(options, otlpmetricgrpc.WithTimeout(timeout))
 		}
 		return otlpmetricgrpc.New(context.Background(), options...)
 	}
@@ -394,8 +212,8 @@ func makeOTLPExporter(config MetricsOTLPConfig) (sdkmetric.Exporter, error) {
 	if len(headers) > 0 {
 		options = append(options, otlpmetrichttp.WithHeaders(headers))
 	}
-	if config.TimeoutSeconds != 0 {
-		options = append(options, otlpmetrichttp.WithTimeout(time.Duration(config.TimeoutSeconds)*time.Second))
+	if timeout, ok := otlpTimeout(config); ok {
+		options = append(options, otlpmetrichttp.WithTimeout(timeout))
 	}
 	return otlpmetrichttp.New(context.Background(), options...)
 }
@@ -522,14 +340,14 @@ func (m *Metrics) UpstreamDialed(ctx context.Context, err error) {
 	if !m.enabled {
 		return
 	}
-	m.upstreamTotal.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(m.attrs.resultAttributes(err)...)))
+	m.upstreamTotal.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(m.attrs.outcomeAttributes(err)...)))
 }
 
 func (m *Metrics) AuthFinished(ctx context.Context, method string, status int, err error, duration time.Duration) {
 	if !m.enabled {
 		return
 	}
-	attrs := append(m.attrs.resultAttributes(err), m.attrs.authMethod.String(method), m.attrs.authStatus.Int(status))
+	attrs := append(m.attrs.outcomeAttributes(err), m.attrs.sshmuxAuthMethod.String(method), m.attrs.sshmuxAuthStatus.Int(status))
 	set := metric.WithAttributeSet(attribute.NewSet(attrs...))
 	m.authRequestsTotal.Add(ctx, 1, set)
 	m.authDuration.Record(ctx, duration.Seconds(), set)
@@ -539,7 +357,7 @@ func (m *Metrics) AuthFinished(ctx context.Context, method string, status int, e
 // dimensions the connection metrics are grouped by, unless the grouping has
 // been turned off.
 func (m *Metrics) connectionAttributeSet(info connectionInfo, err error) attribute.Set {
-	attrs := m.attrs.resultAttributes(err)
+	attrs := m.attrs.outcomeAttributes(err)
 	if m.groupConnections {
 		attrs = append(attrs,
 			m.attrs.userName.String(valueOrDefault(info.Username, unknownAttributeValue)),
@@ -550,7 +368,7 @@ func (m *Metrics) connectionAttributeSet(info connectionInfo, err error) attribu
 	return attribute.NewSet(attrs...)
 }
 
-func (n attributeNames) resultAttributes(err error) []attribute.KeyValue {
+func (n attributeNames) outcomeAttributes(err error) []attribute.KeyValue {
 	if err == nil {
 		return []attribute.KeyValue{n.success()}
 	}
@@ -573,26 +391,4 @@ func errorType(err error) string {
 		return "timeout"
 	}
 	return "other"
-}
-
-func boolOrDefault(value *bool, fallback bool) bool {
-	if value == nil {
-		return fallback
-	}
-	return *value
-}
-
-func valueOrDefault(value string, fallback string) string {
-	if value == "" {
-		return fallback
-	}
-	return value
-}
-
-func buildVersion() string {
-	info, ok := debug.ReadBuildInfo()
-	if !ok || info.Main.Version == "" {
-		return "unknown"
-	}
-	return info.Main.Version
 }

--- a/metrics.go
+++ b/metrics.go
@@ -575,20 +575,6 @@ func errorType(err error) string {
 	return "other"
 }
 
-// instrumentedAuthenticator records the outcome and latency of every auth API
-// request made through the wrapped Authenticator.
-type instrumentedAuthenticator struct {
-	inner   Authenticator
-	metrics *Metrics
-}
-
-func (a *instrumentedAuthenticator) Auth(request AuthRequest, username string) (int, *AuthResponse, error) {
-	start := time.Now()
-	status, response, err := a.inner.Auth(request, username)
-	a.metrics.AuthFinished(context.Background(), request.Method, status, err, time.Since(start))
-	return status, response, err
-}
-
 func boolOrDefault(value *bool, fallback bool) bool {
 	if value == nil {
 		return fallback

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -142,46 +142,6 @@ func TestMetricsPrometheusPathNormalized(t *testing.T) {
 	}
 }
 
-type stubAuthenticator struct {
-	status int
-	err    error
-}
-
-func (a *stubAuthenticator) Auth(AuthRequest, string) (int, *AuthResponse, error) {
-	return a.status, nil, a.err
-}
-
-func TestInstrumentedAuthenticator(t *testing.T) {
-	metrics := prometheusMetrics(t)
-	authenticator := &instrumentedAuthenticator{
-		inner:   &stubAuthenticator{status: 401},
-		metrics: metrics,
-	}
-	status, _, err := authenticator.Auth(AuthRequest{Method: "publickey"}, "vlab")
-	if err != nil || status != 401 {
-		t.Fatalf("Auth() = (%d, %v), want (401, nil)", status, err)
-	}
-
-	failing := &instrumentedAuthenticator{
-		inner:   &stubAuthenticator{err: io.ErrUnexpectedEOF},
-		metrics: metrics,
-	}
-	if _, _, err := failing.Auth(AuthRequest{Method: "keyboard-interactive"}, "vlab"); err == nil {
-		t.Fatal("Auth() error = nil, want an error")
-	}
-
-	body := scrape(t, metrics)
-	for _, want := range []string{
-		`sshmux_auth_requests_total{event_outcome="success",sshmux_auth_method="publickey",sshmux_auth_status="401"} 1`,
-		`sshmux_auth_requests_total{error_type="eof",event_outcome="failure",sshmux_auth_method="keyboard-interactive",sshmux_auth_status="0"} 1`,
-		`sshmux_auth_duration_seconds_count{event_outcome="success",sshmux_auth_method="publickey",sshmux_auth_status="401"} 1`,
-	} {
-		if !strings.Contains(body, want) {
-			t.Errorf("scrape output does not contain %q:\n%s", want, body)
-		}
-	}
-}
-
 func TestMetricsOTLPHTTPExport(t *testing.T) {
 	requests := make(chan string, 4)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -12,10 +12,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.43.0"
 )
 
 // testConnection is the connection identity used by the metric assertions.
@@ -41,7 +37,7 @@ func prometheusMetrics(t *testing.T) *Metrics {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), metricsShutdownTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), otelShutdownTimeout)
 		defer cancel()
 		metrics.Shutdown(ctx)
 	})
@@ -140,7 +136,7 @@ func TestMetricsPrometheusPathNormalized(t *testing.T) {
 	}
 }
 
-func TestMetricsOTLPHTTPExport(t *testing.T) {
+func TestMetricsOTLPExport(t *testing.T) {
 	requests := make(chan string, 4)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests <- r.URL.Path
@@ -150,7 +146,7 @@ func TestMetricsOTLPHTTPExport(t *testing.T) {
 
 	metrics, err := makeMetrics(MetricsConfig{
 		Enabled: true,
-		OTLP: MetricsOTLPConfig{
+		OTLP: OTLPConfig{
 			Enabled:  true,
 			Endpoint: server.URL + "/v1/metrics",
 			Headers:  []HTTPHeaderConfig{{Name: "Authorization", Value: "ApiKey 12345678"}},
@@ -165,7 +161,7 @@ func TestMetricsOTLPHTTPExport(t *testing.T) {
 	metrics.ConnectionAccepted(context.Background())
 
 	// Shutdown flushes the periodic reader, so an export must have happened.
-	ctx, cancel := context.WithTimeout(context.Background(), metricsShutdownTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), otelShutdownTimeout)
 	defer cancel()
 	metrics.Shutdown(ctx)
 
@@ -179,27 +175,27 @@ func TestMetricsOTLPHTTPExport(t *testing.T) {
 	}
 }
 
-func TestMakeOTLPExporterErrors(t *testing.T) {
+func TestMakeOTLPMetricExporterErrors(t *testing.T) {
 	cases := []struct {
 		name   string
-		config MetricsOTLPConfig
+		config OTLPConfig
 	}{
-		{"bad scheme", MetricsOTLPConfig{Enabled: true, Endpoint: "udp://127.0.0.1:4318"}},
-		{"unknown protocol", MetricsOTLPConfig{Enabled: true, Endpoint: "http://127.0.0.1:4318", Protocol: "thrift"}},
-		{"grpc with path", MetricsOTLPConfig{Enabled: true, Endpoint: "http://127.0.0.1:4317/v1/metrics", Protocol: "grpc"}},
+		{"bad scheme", OTLPConfig{Enabled: true, Endpoint: "udp://127.0.0.1:4318"}},
+		{"unknown protocol", OTLPConfig{Enabled: true, Endpoint: "http://127.0.0.1:4318", Protocol: "thrift"}},
+		{"grpc with path", OTLPConfig{Enabled: true, Endpoint: "http://127.0.0.1:4317/v1/metrics", Protocol: "grpc"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if _, err := makeOTLPExporter(tc.config); err == nil {
-				t.Fatal("makeOTLPExporter() error = nil, want an error")
+			if _, err := makeOTLPMetricExporter(tc.config); err == nil {
+				t.Fatal("makeOTLPMetricExporter() error = nil, want an error")
 			}
 		})
 	}
 }
 
-// TestOTLPEndpointPaths pins that a configured endpoint is used verbatim, the
+// TestMetricsOTLPEndpointPaths pins that a configured endpoint is used verbatim, the
 // way a signal-specific endpoint is, with no signal path appended to it.
-func TestOTLPEndpointPaths(t *testing.T) {
+func TestMetricsOTLPEndpointPaths(t *testing.T) {
 	cases := []struct{ endpoint, want string }{
 		{"http://%s/v1/metrics", "/v1/metrics"},
 		{"http://%s/otlp/v1/metrics", "/otlp/v1/metrics"},
@@ -214,7 +210,7 @@ func TestOTLPEndpointPaths(t *testing.T) {
 			host := strings.TrimPrefix(server.URL, "http://")
 			exportOnce(t, MetricsConfig{
 				Enabled: true,
-				OTLP:    MetricsOTLPConfig{Enabled: true, Endpoint: fmt.Sprintf(tc.endpoint, host)},
+				OTLP:    OTLPConfig{Enabled: true, Endpoint: fmt.Sprintf(tc.endpoint, host)},
 			})
 			if got := awaitExport(t, requests).Path; got != tc.want {
 				t.Fatalf("endpoint %q posted to %q, want %q", tc.endpoint, got, tc.want)
@@ -223,17 +219,17 @@ func TestOTLPEndpointPaths(t *testing.T) {
 	}
 }
 
-func TestMakeOTLPExporterProtocols(t *testing.T) {
+func TestMakeOTLPMetricExporterProtocols(t *testing.T) {
 	for _, protocol := range []string{"", "http", "http/protobuf", "grpc"} {
 		endpoint := "https://otel.example.com:4318/otlp"
 		if protocol == "grpc" {
 			endpoint = "https://otel.example.com:4317"
 		}
-		exporter, err := makeOTLPExporter(MetricsOTLPConfig{Enabled: true, Protocol: protocol, Endpoint: endpoint})
+		exporter, err := makeOTLPMetricExporter(OTLPConfig{Enabled: true, Protocol: protocol, Endpoint: endpoint})
 		if err != nil {
 			t.Fatalf("protocol %q: %v", protocol, err)
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), metricsShutdownTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), otelShutdownTimeout)
 		exporter.Shutdown(ctx)
 		cancel()
 	}
@@ -276,60 +272,6 @@ func TestConnectionGrouping(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("scrape output does not contain %q:\n%s", want, body)
 		}
-	}
-}
-
-func TestOTLPProtocolPrecedence(t *testing.T) {
-	cases := []struct {
-		name       string
-		configured string
-		env        map[string]string
-		want       string
-		wantErr    bool
-	}{
-		{name: "default", want: "http/protobuf"},
-		{name: "configured", configured: "grpc", want: "grpc"},
-		{
-			name: "from the generic environment variable",
-			env:  map[string]string{envOTLPProtocol: "grpc"},
-			want: "grpc",
-		},
-		{
-			name: "the metrics environment variable wins over the generic one",
-			env:  map[string]string{envOTLPProtocol: "grpc", envOTLPMetricsProtocol: "http/protobuf"},
-			want: "http/protobuf",
-		},
-		{
-			name:       "configuration wins over the environment",
-			configured: "http",
-			env:        map[string]string{envOTLPMetricsProtocol: "grpc"},
-			want:       "http/protobuf",
-		},
-		{
-			name:    "http/json is not supported",
-			env:     map[string]string{envOTLPProtocol: "http/json"},
-			wantErr: true,
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			for key, value := range tc.env {
-				t.Setenv(key, value)
-			}
-			got, err := otlpProtocol(tc.configured)
-			if tc.wantErr {
-				if err == nil {
-					t.Fatalf("otlpProtocol(%q) error = nil, want an error", tc.configured)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatal(err)
-			}
-			if got != tc.want {
-				t.Fatalf("otlpProtocol(%q) = %q, want %q", tc.configured, got, tc.want)
-			}
-		})
 	}
 }
 
@@ -376,26 +318,26 @@ func exportOnce(t *testing.T, config MetricsConfig) {
 		t.Fatal(err)
 	}
 	metrics.ConnectionAccepted(t.Context())
-	ctx, cancel := context.WithTimeout(context.Background(), metricsShutdownTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), otelShutdownTimeout)
 	defer cancel()
 	metrics.Shutdown(ctx)
 }
 
-// TestOTLPEndpointFromEnvironment covers the other half of the rule: the
+// TestMetricsOTLPEndpointFromEnvironment covers the other half of the rule: the
 // generic environment variable is a base URL, so the signal path is appended.
-func TestOTLPEndpointFromEnvironment(t *testing.T) {
+func TestMetricsOTLPEndpointFromEnvironment(t *testing.T) {
 	server, paths := otlpTestCollector(t)
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", server.URL)
 
 	// No endpoint in the config file, so the environment has to supply it.
-	exportOnce(t, MetricsConfig{Enabled: true, OTLP: MetricsOTLPConfig{Enabled: true}})
+	exportOnce(t, MetricsConfig{Enabled: true, OTLP: OTLPConfig{Enabled: true}})
 
 	if path := awaitExport(t, paths).Path; path != "/v1/metrics" {
 		t.Fatalf("OTLP request path = %q, want %q", path, "/v1/metrics")
 	}
 }
 
-func TestOTLPEndpointConfigWinsOverEnvironment(t *testing.T) {
+func TestMetricsOTLPEndpointConfigWinsOverEnvironment(t *testing.T) {
 	configured, paths := otlpTestCollector(t)
 	unused, unusedPaths := otlpTestCollector(t)
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", unused.URL)
@@ -403,7 +345,7 @@ func TestOTLPEndpointConfigWinsOverEnvironment(t *testing.T) {
 
 	exportOnce(t, MetricsConfig{
 		Enabled: true,
-		OTLP:    MetricsOTLPConfig{Enabled: true, Endpoint: configured.URL + "/otlp/v1/metrics"},
+		OTLP:    OTLPConfig{Enabled: true, Endpoint: configured.URL + "/otlp/v1/metrics"},
 	})
 
 	if path := awaitExport(t, paths).Path; path != "/otlp/v1/metrics" {
@@ -416,13 +358,13 @@ func TestOTLPEndpointConfigWinsOverEnvironment(t *testing.T) {
 	}
 }
 
-func TestOTLPHeadersPrecedence(t *testing.T) {
+func TestMetricsOTLPHeadersPrecedence(t *testing.T) {
 	t.Run("from the environment", func(t *testing.T) {
 		server, requests := otlpTestCollector(t)
 		t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", server.URL)
 		t.Setenv("OTEL_EXPORTER_OTLP_HEADERS", "x-scope-orgid=vlab")
 
-		exportOnce(t, MetricsConfig{Enabled: true, OTLP: MetricsOTLPConfig{Enabled: true}})
+		exportOnce(t, MetricsConfig{Enabled: true, OTLP: OTLPConfig{Enabled: true}})
 
 		if got := awaitExport(t, requests).Header.Get("X-Scope-Orgid"); got != "vlab" {
 			t.Fatalf("X-Scope-OrgID = %q, want %q", got, "vlab")
@@ -433,7 +375,7 @@ func TestOTLPHeadersPrecedence(t *testing.T) {
 		server, requests := otlpTestCollector(t)
 		t.Setenv("OTEL_EXPORTER_OTLP_HEADERS", "x-scope-orgid=from-environment")
 
-		exportOnce(t, MetricsConfig{Enabled: true, OTLP: MetricsOTLPConfig{
+		exportOnce(t, MetricsConfig{Enabled: true, OTLP: OTLPConfig{
 			Enabled:  true,
 			Endpoint: server.URL + "/v1/metrics",
 			Headers:  []HTTPHeaderConfig{{Name: "X-Scope-OrgID", Value: "from-config"}},
@@ -445,14 +387,14 @@ func TestOTLPHeadersPrecedence(t *testing.T) {
 	})
 }
 
-// TestOTLPIntervalFromEnvironment checks that an export happens on the interval
+// TestMetricsOTLPIntervalFromEnvironment checks that an export happens on the interval
 // set by the environment, without a shutdown flush forcing it.
-func TestOTLPIntervalFromEnvironment(t *testing.T) {
+func TestMetricsOTLPIntervalFromEnvironment(t *testing.T) {
 	server, requests := otlpTestCollector(t)
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", server.URL)
 	t.Setenv("OTEL_METRIC_EXPORT_INTERVAL", "200")
 
-	metrics, err := makeMetrics(MetricsConfig{Enabled: true, OTLP: MetricsOTLPConfig{Enabled: true}})
+	metrics, err := makeMetrics(MetricsConfig{Enabled: true, OTLP: OTLPConfig{Enabled: true}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -465,75 +407,6 @@ func TestOTLPIntervalFromEnvironment(t *testing.T) {
 	if path := awaitExport(t, requests).Path; path != "/v1/metrics" {
 		t.Fatalf("OTLP request path = %q, want %q", path, "/v1/metrics")
 	}
-}
-
-func TestMetricsResourceAttributePrecedence(t *testing.T) {
-	fromEnv := resource.NewWithAttributes(semconv.SchemaURL,
-		semconv.ServiceName("from-environment"),
-		semconv.ServiceVersion("v9.9.9"),
-	)
-	unnamed := resource.NewWithAttributes(semconv.SchemaURL,
-		semconv.ServiceName("unknown_service:sshmux"),
-	)
-
-	// The environment supplies the name, so sshmux must not override it.
-	attrs, err := metricsResourceAttributes(MetricsConfig{}, fromEnv)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if name, ok := findAttribute(attrs, semconv.ServiceNameKey); ok {
-		t.Errorf("service.name = %q, want it left to the environment", name)
-	}
-	if version, ok := findAttribute(attrs, semconv.ServiceVersionKey); ok {
-		t.Errorf("service.version = %q, want it left to the environment", version)
-	}
-
-	// An explicit name in the config file wins over the environment.
-	attrs, err = metricsResourceAttributes(MetricsConfig{ServiceName: "from-config"}, fromEnv)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if name, _ := findAttribute(attrs, semconv.ServiceNameKey); name != "from-config" {
-		t.Errorf("service.name = %q, want %q", name, "from-config")
-	}
-
-	// With neither set, sshmux falls back to its own default.
-	attrs, err = metricsResourceAttributes(MetricsConfig{}, unnamed)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if name, _ := findAttribute(attrs, semconv.ServiceNameKey); name != defaultMetricsServiceName {
-		t.Errorf("service.name = %q, want %q", name, defaultMetricsServiceName)
-	}
-	if _, ok := findAttribute(attrs, semconv.ServiceVersionKey); !ok {
-		t.Error("service.version is missing, want the build version")
-	}
-
-	// Attributes from the config file are always applied.
-	attrs, err = metricsResourceAttributes(MetricsConfig{
-		Attributes: []MetricsAttributeConfig{{Name: "env", Value: "staging"}},
-	}, unnamed)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if value, _ := findAttribute(attrs, attribute.Key("env")); value != "staging" {
-		t.Errorf("env = %q, want %q", value, "staging")
-	}
-
-	if _, err := metricsResourceAttributes(MetricsConfig{
-		Attributes: []MetricsAttributeConfig{{Value: "no name"}},
-	}, unnamed); err == nil {
-		t.Error("a nameless resource attribute should be rejected")
-	}
-}
-
-func findAttribute(attrs []attribute.KeyValue, key attribute.Key) (string, bool) {
-	for _, attr := range attrs {
-		if attr.Key == key {
-			return attr.Value.AsString(), true
-		}
-	}
-	return "", false
 }
 
 // countSeries counts the exported sshmux_sessions_total series.
@@ -708,43 +581,10 @@ func TestPrometheusTranslationStrategy(t *testing.T) {
 	})
 }
 
-// TestConventionAttributeNames pins how each convention resolves, and that the
-// two lines currently agree — the property that lets `ecs` be the stable choice
-// today at no cost.
-func TestConventionAttributeNames(t *testing.T) {
-	for _, convention := range []MetricsConvention{"", MetricsConventionDefault} {
-		names, err := conventionAttributeNames(convention)
-		if err != nil {
-			t.Fatalf("convention %q: %v", convention, err)
-		}
-		if names != defaultAttributeNames {
-			t.Errorf("convention %q did not resolve to the semantic conventions", convention)
-		}
-	}
-	names, err := conventionAttributeNames(MetricsConventionECS)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if names != ecsAttributeNames {
-		t.Error(`convention "ecs" did not resolve to the Elastic Common Schema`)
-	}
-
-	// The conventions adopted these fields from ECS, so the two lines name
-	// every attribute identically. This will stop holding when they diverge,
-	// and the test is what will say so.
-	if defaultAttributeNames != ecsAttributeNames {
-		t.Log("the conventions have diverged; the README table needs updating")
-	}
-
-	if _, err := conventionAttributeNames("nonsense"); err == nil {
-		t.Error("an unknown convention should be refused")
-	}
-}
-
-// TestConventionEndToEnd checks that the configured convention reaches the
+// TestMetricsConvention checks that the configured convention reaches the
 // exported labels.
-func TestConventionEndToEnd(t *testing.T) {
-	for _, convention := range []MetricsConvention{MetricsConventionDefault, MetricsConventionECS} {
+func TestMetricsConvention(t *testing.T) {
+	for _, convention := range []AttributeConvention{AttributeConventionDefault, AttributeConventionECS} {
 		t.Run(string(convention), func(t *testing.T) {
 			metrics, err := makeMetrics(MetricsConfig{
 				Enabled:    true,

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -9,8 +9,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"os/exec"
-	"os/user"
 	"strings"
 	"testing"
 	"time"
@@ -258,55 +256,6 @@ func TestErrorType(t *testing.T) {
 	for _, tc := range cases {
 		if got := errorType(tc.err); got != tc.want {
 			t.Errorf("errorType(%v) = %q, want %q", tc.err, got, tc.want)
-		}
-	}
-}
-
-// TestServerMetricsWiring checks that a connection served by the real server
-// shows up in the exported metrics, i.e. that the instruments are wired into
-// the connection handler and not just reachable in isolation.
-func TestServerMetricsWiring(t *testing.T) {
-	sshmux, err := makeServer(Config{
-		Address: "127.0.0.1:0",
-		SSH:     SSHConfig{HostKeys: []SSHKeyConfig{{Path: "fixtures/ssh_host_ed25519_key"}}},
-		Auth:    AuthConfig{Endpoint: "http://127.0.0.1:5000", Version: "v1"},
-		Metrics: MetricsConfig{
-			Enabled:    true,
-			Prometheus: MetricsPrometheusConfig{Enabled: true, Address: "127.0.0.1:0"},
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := sshmux.Start(); err != nil {
-		t.Fatal(err)
-	}
-	defer sshmux.Shutdown()
-
-	// A connection that goes away before the SSH handshake completes still has
-	// to be accounted for as an accepted and then failed session.
-	conn, err := net.Dial("tcp", sshmux.Addr().String())
-	if err != nil {
-		t.Fatal(err)
-	}
-	conn.Close()
-
-	deadline := time.Now().Add(5 * time.Second)
-	var body string
-	for time.Now().Before(deadline) {
-		body = scrape(t, sshmux.Metrics)
-		if strings.Contains(body, "sshmux_sessions_total{") {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	for _, want := range []string{
-		`sshmux_connections_total 1`,
-		`sshmux_connections_active 0`,
-		`sshmux_sessions_total{`,
-	} {
-		if !strings.Contains(body, want) {
-			t.Errorf("scrape output does not contain %q:\n%s", want, body)
 		}
 	}
 }
@@ -585,67 +534,6 @@ func findAttribute(attrs []attribute.KeyValue, key attribute.Key) (string, bool)
 		}
 	}
 	return "", false
-}
-
-// TestServerMetricsUpstreamGrouping drives a real SSH client through sshmux and
-// checks that the backend address the auth API returned reaches the metrics.
-func TestServerMetricsUpstreamGrouping(t *testing.T) {
-	if _, err := exec.LookPath("sshd"); err != nil {
-		t.Skip("sshd is not available")
-	}
-	initEnv(t)
-	enableProxy = false
-
-	currentUser, err := user.Current()
-	if err != nil {
-		t.Fatal(err)
-	}
-	sshmux, err := makeServer(Config{
-		Address: "127.0.0.1:0",
-		SSH:     SSHConfig{HostKeys: []SSHKeyConfig{{Path: "fixtures/ssh_host_ed25519_key"}}},
-		Auth:    AuthConfig{Endpoint: "http://" + apiServerAddr.String(), Version: "v1"},
-		Metrics: MetricsConfig{
-			Enabled:    true,
-			Prometheus: MetricsPrometheusConfig{Enabled: true, Address: "127.0.0.1:0"},
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := sshmux.Start(); err != nil {
-		t.Fatal(err)
-	}
-	defer sshmux.Shutdown()
-
-	sshd := onetimeSSHDServer(t)
-	defer stopSSHD(t, sshd)
-	address := sshmux.Addr().(*net.TCPAddr)
-	sshCommand := exec.Command(
-		"ssh", "-p", fmt.Sprint(address.Port),
-		"-o", "StrictHostKeyChecking=no",
-		"-o", "ControlMaster=no",
-		"-i", "fixtures/ssh_id_rsa",
-		"-o", "IdentityAgent=no",
-		address.IP.String(), "uname")
-	sshCommand.Dir, _ = os.Getwd()
-	if err := sshCommand.Run(); err != nil {
-		t.Fatal("ssh: ", err)
-	}
-
-	// The session is recorded once its handler winds down, shortly after the
-	// client exits.
-	want := fmt.Sprintf(`sshmux_sessions_total{event_outcome="success",server_address=%q,server_port="%d",user_name=%q} 1`,
-		sshdServerAddr.IP.String(), sshdServerAddr.Port, currentUser.Username)
-	deadline := time.Now().Add(5 * time.Second)
-	var body string
-	for time.Now().Before(deadline) {
-		body = scrape(t, sshmux.Metrics)
-		if strings.Contains(body, want) {
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	t.Errorf("scrape output does not contain %q:\n%s", want, body)
 }
 
 // countSeries counts the exported sshmux_sessions_total series.

--- a/otel.go
+++ b/otel.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"runtime/debug"
@@ -36,41 +37,65 @@ const (
 // attributeNames is the set of attribute keys one convention resolves to.
 // Only the names differ between conventions; the values never do.
 // connectionInfo is the per-connection state the metrics and the spans are
-// recorded from.
-// Fields are zero until they become known: Username is only set once the client
-// has sent its first auth request, and the upstream only once the auth API has
-// answered.
+// recorded from. Fields are zero until they become known: Username is only set
+// once the client has sent its first auth request, and the upstream only once
+// the auth API has answered.
 type connectionInfo struct {
 	Username string
 	// UpstreamHost and UpstreamPort are the backend the auth API returned,
 	// before any PROXY protocol override.
 	UpstreamHost string
 	UpstreamPort uint16
+	// ClientHost and ClientPort are the downstream address, as the PROXY
+	// protocol header reports it where there is one, and ClientPeer the address
+	// actually connected from. They are for the spans: grouping metrics by
+	// client would be a series per connection.
+	ClientHost string
+	ClientPort uint16
+	ClientPeer net.Addr
+	// ProtocolVersion is the SSH protocol version the client identified with,
+	// e.g. "2.0" out of "SSH-2.0-OpenSSH_9.9".
+	ProtocolVersion string
 	// Established records whether the handshake completed.
 	Established bool
 }
 
 type attributeNames struct {
-	eventOutcome     attribute.Key
-	errorType        attribute.Key
-	userName         attribute.Key
-	serverAddress    attribute.Key
-	serverPort       attribute.Key
-	sshmuxAuthMethod attribute.Key
-	sshmuxAuthStatus attribute.Key
+	eventOutcome           attribute.Key
+	errorType              attribute.Key
+	userName               attribute.Key
+	clientAddress          attribute.Key
+	clientPort             attribute.Key
+	serverAddress          attribute.Key
+	serverPort             attribute.Key
+	networkProtocolName    attribute.Key
+	networkProtocolVersion attribute.Key
+	// A span's peer is the other end of the network connection it covers, as
+	// against the logical end behind any intermediary. Its kind fixes which
+	// side that is: the client for a server span, the callee for a client span.
+	networkPeerAddress attribute.Key
+	networkPeerPort    attribute.Key
+	sshmuxAuthMethod   attribute.Key
+	sshmuxAuthStatus   attribute.Key
 }
 
 // defaultAttributeNames resolves each attribute against the OpenTelemetry
 // semantic conventions first, then the Elastic Common Schema, then sshmux's
 // own namespace, and follows the conventions wherever they move.
 var defaultAttributeNames = attributeNames{
-	errorType:        attribute.Key("error.type"),     // semconv
-	userName:         attribute.Key("user.name"),      // semconv
-	serverAddress:    attribute.Key("server.address"), // semconv
-	serverPort:       attribute.Key("server.port"),    // semconv
-	eventOutcome:     attribute.Key("event.outcome"),  // ECS; semconv has no equivalent
-	sshmuxAuthMethod: attribute.Key("sshmux.auth.method"),
-	sshmuxAuthStatus: attribute.Key("sshmux.auth.status"),
+	errorType:              attribute.Key("error.type"),               // semconv
+	userName:               attribute.Key("user.name"),                // semconv
+	clientAddress:          attribute.Key("client.address"),           // semconv
+	clientPort:             attribute.Key("client.port"),              // semconv
+	serverAddress:          attribute.Key("server.address"),           // semconv
+	serverPort:             attribute.Key("server.port"),              // semconv
+	networkProtocolName:    attribute.Key("network.protocol.name"),    // semconv
+	networkProtocolVersion: attribute.Key("network.protocol.version"), // semconv
+	networkPeerAddress:     attribute.Key("network.peer.address"),     // semconv
+	networkPeerPort:        attribute.Key("network.peer.port"),        // semconv
+	eventOutcome:           attribute.Key("event.outcome"),            // ECS; semconv has no equivalent
+	sshmuxAuthMethod:       attribute.Key("sshmux.auth.method"),
+	sshmuxAuthStatus:       attribute.Key("sshmux.auth.status"),
 }
 
 // ecsAttributeNames resolves against the Elastic Common Schema only, which does
@@ -80,13 +105,21 @@ var defaultAttributeNames = attributeNames{
 // because the conventions adopted these fields from ECS. The two are kept
 // apart so that they can diverge without the configuration changing shape.
 var ecsAttributeNames = attributeNames{
-	errorType:        attribute.Key("error.type"),
-	userName:         attribute.Key("user.name"),
-	serverAddress:    attribute.Key("server.address"),
-	serverPort:       attribute.Key("server.port"),
-	eventOutcome:     attribute.Key("event.outcome"),
-	sshmuxAuthMethod: attribute.Key("sshmux.auth.method"),
-	sshmuxAuthStatus: attribute.Key("sshmux.auth.status"),
+	errorType:     attribute.Key("error.type"),
+	userName:      attribute.Key("user.name"),
+	clientAddress: attribute.Key("client.address"),
+	clientPort:    attribute.Key("client.port"),
+	serverAddress: attribute.Key("server.address"),
+	serverPort:    attribute.Key("server.port"),
+	// The two attributes the conventions do not share: ECS names the
+	// application protocol without the namespace the semantic conventions put
+	// it in, and has nothing for its version. An empty key drops the attribute.
+	networkProtocolName: attribute.Key("network.protocol"),
+	networkPeerAddress:  attribute.Key("network.peer.address"),
+	networkPeerPort:     attribute.Key("network.peer.port"),
+	eventOutcome:        attribute.Key("event.outcome"),
+	sshmuxAuthMethod:    attribute.Key("sshmux.auth.method"),
+	sshmuxAuthStatus:    attribute.Key("sshmux.auth.status"),
 }
 
 // conventionAttributeNames resolves the configured convention.

--- a/otel.go
+++ b/otel.go
@@ -1,0 +1,247 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"runtime/debug"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.43.0"
+)
+
+// Plumbing shared by the OpenTelemetry signals: the attribute names a
+// convention resolves to, an OTLP exporter's settings, and the resource that
+// identifies this process.
+
+const (
+	defaultServiceName  = "sshmux"
+	otelScopeName       = "github.com/USTC-vlab/sshmux"
+	otelShutdownTimeout = 5 * time.Second
+	// unknownAttributeValue is recorded for a grouping attribute whose value is
+	// not known, e.g. the username of a connection that failed before auth.
+	unknownAttributeValue = "unknown"
+)
+
+const (
+	envOTLPProtocol        = "OTEL_EXPORTER_OTLP_PROTOCOL"
+	envOTLPMetricsProtocol = "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"
+	envOTLPTracesProtocol  = "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"
+)
+
+// attributeNames is the set of attribute keys one convention resolves to.
+// Only the names differ between conventions; the values never do.
+// connectionInfo is the per-connection state the metrics and the spans are
+// recorded from.
+// Fields are zero until they become known: Username is only set once the client
+// has sent its first auth request, and the upstream only once the auth API has
+// answered.
+type connectionInfo struct {
+	Username string
+	// UpstreamHost and UpstreamPort are the backend the auth API returned,
+	// before any PROXY protocol override.
+	UpstreamHost string
+	UpstreamPort uint16
+	// Established records whether the handshake completed.
+	Established bool
+}
+
+type attributeNames struct {
+	eventOutcome     attribute.Key
+	errorType        attribute.Key
+	userName         attribute.Key
+	serverAddress    attribute.Key
+	serverPort       attribute.Key
+	sshmuxAuthMethod attribute.Key
+	sshmuxAuthStatus attribute.Key
+}
+
+// defaultAttributeNames resolves each attribute against the OpenTelemetry
+// semantic conventions first, then the Elastic Common Schema, then sshmux's
+// own namespace, and follows the conventions wherever they move.
+var defaultAttributeNames = attributeNames{
+	errorType:        attribute.Key("error.type"),     // semconv
+	userName:         attribute.Key("user.name"),      // semconv
+	serverAddress:    attribute.Key("server.address"), // semconv
+	serverPort:       attribute.Key("server.port"),    // semconv
+	eventOutcome:     attribute.Key("event.outcome"),  // ECS; semconv has no equivalent
+	sshmuxAuthMethod: attribute.Key("sshmux.auth.method"),
+	sshmuxAuthStatus: attribute.Key("sshmux.auth.status"),
+}
+
+// ecsAttributeNames resolves against the Elastic Common Schema only, which does
+// not move when the semantic conventions do.
+//
+// It currently names every attribute identically to defaultAttributeNames,
+// because the conventions adopted these fields from ECS. The two are kept
+// apart so that they can diverge without the configuration changing shape.
+var ecsAttributeNames = attributeNames{
+	errorType:        attribute.Key("error.type"),
+	userName:         attribute.Key("user.name"),
+	serverAddress:    attribute.Key("server.address"),
+	serverPort:       attribute.Key("server.port"),
+	eventOutcome:     attribute.Key("event.outcome"),
+	sshmuxAuthMethod: attribute.Key("sshmux.auth.method"),
+	sshmuxAuthStatus: attribute.Key("sshmux.auth.status"),
+}
+
+// conventionAttributeNames resolves the configured convention.
+func conventionAttributeNames(convention AttributeConvention) (attributeNames, error) {
+	switch convention {
+	case "", AttributeConventionDefault:
+		return defaultAttributeNames, nil
+	case AttributeConventionECS:
+		return ecsAttributeNames, nil
+	default:
+		// Unreachable: validateMetricsConfig accepts only the names above.
+		return attributeNames{}, fmt.Errorf("unsupported convention: %s", convention)
+	}
+}
+
+func (n attributeNames) success() attribute.KeyValue { return n.eventOutcome.String("success") }
+func (n attributeNames) failure() attribute.KeyValue { return n.eventOutcome.String("failure") }
+
+func otelResource(serviceName string, configured []ResourceAttributeConfig) (*resource.Resource, error) {
+	// resource.Default reads OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES.
+	base := resource.Default()
+	attrs, err := otelResourceAttributes(serviceName, configured, base)
+	if err != nil {
+		return nil, err
+	}
+	// The base resource and our attributes share the same semantic convention
+	// schema, so the merge below never conflicts. Attributes from the second
+	// resource win, which is why only the ones the environment did not already
+	// provide are added.
+	res, err := resource.Merge(base, resource.NewWithAttributes(semconv.SchemaURL, attrs...))
+	if err != nil {
+		return nil, fmt.Errorf("failed to build resource: %w", err)
+	}
+	return res, nil
+}
+
+// otelResourceAttributes returns the resource attributes to layer on top of
+// base, honouring the config file over the environment over sshmux's defaults.
+func otelResourceAttributes(serviceName string, configured []ResourceAttributeConfig, base *resource.Resource) ([]attribute.KeyValue, error) {
+	var attrs []attribute.KeyValue
+	// resource.Default only reports an `unknown_service:...` name when neither
+	// OTEL_SERVICE_NAME nor OTEL_RESOURCE_ATTRIBUTES supplied one.
+	if serviceName != "" {
+		attrs = append(attrs, semconv.ServiceName(serviceName))
+	} else if name, ok := resourceAttribute(base, semconv.ServiceNameKey); !ok || strings.HasPrefix(name, "unknown_service") {
+		attrs = append(attrs, semconv.ServiceName(defaultServiceName))
+	}
+	if _, ok := resourceAttribute(base, semconv.ServiceVersionKey); !ok {
+		attrs = append(attrs, semconv.ServiceVersion(buildVersion()))
+	}
+	if _, ok := resourceAttribute(base, semconv.HostNameKey); !ok {
+		if hostname, err := os.Hostname(); err == nil && hostname != "" {
+			attrs = append(attrs, semconv.HostName(hostname))
+		}
+	}
+	for _, attr := range configured {
+		if attr.Name == "" {
+			return nil, errors.New("resource attributes must have a name")
+		}
+		attrs = append(attrs, attribute.String(attr.Name, attr.Value))
+	}
+	return attrs, nil
+}
+
+func resourceAttribute(res *resource.Resource, key attribute.Key) (string, bool) {
+	if res == nil {
+		return "", false
+	}
+	for _, attr := range res.Attributes() {
+		if attr.Key == key {
+			return attr.Value.AsString(), true
+		}
+	}
+	return "", false
+}
+
+// otlpProtocol resolves the OTLP transport, honouring the config file over
+// OTEL_EXPORTER_OTLP_METRICS_PROTOCOL over OTEL_EXPORTER_OTLP_PROTOCOL. Unlike
+// the endpoint and the headers, the protocol selects which exporter package is
+// used, so it cannot be delegated to the exporter itself.
+func otlpProtocol(configured string, signalEnv string) (string, error) {
+	protocol := configured
+	for _, key := range []string{signalEnv, envOTLPProtocol} {
+		if protocol != "" {
+			break
+		}
+		protocol = strings.TrimSpace(os.Getenv(key))
+	}
+	switch protocol {
+	case "", "http", "http/protobuf":
+		return "http/protobuf", nil
+	case "grpc":
+		return "grpc", nil
+	default:
+		return "", fmt.Errorf("unsupported OTLP protocol: %s", protocol)
+	}
+}
+
+func buildVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok || info.Main.Version == "" {
+		return "unknown"
+	}
+	return info.Main.Version
+}
+
+// otlpEndpoint parses a configured endpoint. A nil result means none was set,
+// so the exporter falls back to OTEL_EXPORTER_OTLP_[SIGNAL_]ENDPOINT and in
+// turn to the OTLP defaults.
+func otlpEndpoint(config OTLPConfig, protocol string) (*url.URL, error) {
+	if config.Endpoint == "" {
+		return nil, nil
+	}
+	endpoint, err := url.Parse(config.Endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse OTLP endpoint: %w", err)
+	}
+	switch endpoint.Scheme {
+	case "http", "https":
+	default:
+		return nil, fmt.Errorf("unsupported OTLP endpoint scheme: %s", endpoint.Scheme)
+	}
+	if protocol == "grpc" && strings.Trim(endpoint.Path, "/") != "" {
+		return nil, fmt.Errorf("gRPC OTLP endpoint must not have a path: %s", config.Endpoint)
+	}
+	return endpoint, nil
+}
+
+func otlpHeaders(config OTLPConfig) map[string]string {
+	headers := make(map[string]string, len(config.Headers))
+	for _, header := range config.Headers {
+		headers[header.Name] = header.Value
+	}
+	return headers
+}
+
+// otlpTimeout reports the configured export timeout, and whether one was set:
+// leaving it unset defers to OTEL_EXPORTER_OTLP_[SIGNAL_]TIMEOUT.
+func otlpTimeout(config OTLPConfig) (time.Duration, bool) {
+	if config.TimeoutSeconds == 0 {
+		return 0, false
+	}
+	return time.Duration(config.TimeoutSeconds) * time.Second, true
+}
+
+func boolOrDefault(value *bool, fallback bool) bool {
+	if value == nil {
+		return fallback
+	}
+	return *value
+}
+
+func valueOrDefault(value string, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+	return value
+}

--- a/otel_test.go
+++ b/otel_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"reflect"
+	"slices"
 	"testing"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -145,11 +147,24 @@ func TestConventionAttributeNames(t *testing.T) {
 		t.Error(`convention "ecs" did not resolve to the Elastic Common Schema`)
 	}
 
-	// The conventions adopted these fields from ECS, so the two lines name
-	// every attribute identically. This will stop holding when they diverge,
-	// and the test is what will say so.
-	if defaultAttributeNames != ecsAttributeNames {
-		t.Log("the conventions have diverged; the README table needs updating")
+	// The conventions adopted most of these fields from ECS, so they name all
+	// but the application protocol and its version identically. A further
+	// difference needs a row in the README table, and this is what says so.
+	var differing []string
+	defaults, ecs := reflect.ValueOf(defaultAttributeNames), reflect.ValueOf(ecsAttributeNames)
+	for i := range defaults.NumField() {
+		// String, not Interface: the fields are unexported, and every one of
+		// them is an attribute.Key.
+		if defaults.Field(i).String() != ecs.Field(i).String() {
+			differing = append(differing, defaults.Type().Field(i).Name)
+		}
+	}
+	want := []string{"networkProtocolName", "networkProtocolVersion"}
+	if !slices.Equal(differing, want) {
+		t.Errorf("the conventions differ in %v, want %v", differing, want)
+	}
+	if ecsAttributeNames.networkProtocolVersion != "" {
+		t.Error("ECS has no name for the protocol version, want the attribute dropped")
 	}
 
 	if _, err := conventionAttributeNames("nonsense"); err == nil {

--- a/otel_test.go
+++ b/otel_test.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.43.0"
+)
+
+func TestOTLPProtocolPrecedence(t *testing.T) {
+	cases := []struct {
+		name       string
+		configured string
+		generic    string
+		signal     string
+		want       string
+		wantErr    bool
+	}{
+		{name: "default", want: "http/protobuf"},
+		{name: "configured", configured: "grpc", want: "grpc"},
+		{name: "from the generic environment variable", generic: "grpc", want: "grpc"},
+		{name: "the signal variable wins over the generic one", generic: "grpc", signal: "http/protobuf", want: "http/protobuf"},
+		{name: "configuration wins over the environment", configured: "http", signal: "grpc", want: "http/protobuf"},
+		{name: "http/json is not supported", generic: "http/json", wantErr: true},
+	}
+	// The rules are the same for every signal, so each case is checked against
+	// each of the signal variables.
+	signals := []struct{ name, env string }{
+		{"metrics", envOTLPMetricsProtocol},
+		{"traces", envOTLPTracesProtocol},
+	}
+	for _, signal := range signals {
+		t.Run(signal.name, func(t *testing.T) {
+			for _, tc := range cases {
+				t.Run(tc.name, func(t *testing.T) {
+					// Both variables are set on every case, so that whatever
+					// the environment running the tests carries is not read.
+					t.Setenv(envOTLPProtocol, tc.generic)
+					t.Setenv(signal.env, tc.signal)
+
+					got, err := otlpProtocol(tc.configured, signal.env)
+					if tc.wantErr {
+						if err == nil {
+							t.Fatalf("otlpProtocol(%q) error = nil, want an error", tc.configured)
+						}
+						return
+					}
+					if err != nil {
+						t.Fatal(err)
+					}
+					if got != tc.want {
+						t.Fatalf("otlpProtocol(%q) = %q, want %q", tc.configured, got, tc.want)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestResourceAttributePrecedence(t *testing.T) {
+	fromEnv := resource.NewWithAttributes(semconv.SchemaURL,
+		semconv.ServiceName("from-environment"),
+		semconv.ServiceVersion("v9.9.9"),
+	)
+	unnamed := resource.NewWithAttributes(semconv.SchemaURL,
+		semconv.ServiceName("unknown_service:sshmux"),
+	)
+
+	// The environment supplies the name, so sshmux must not override it.
+	attrs, err := otelResourceAttributes("", nil, fromEnv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name, ok := findAttribute(attrs, semconv.ServiceNameKey); ok {
+		t.Errorf("service.name = %q, want it left to the environment", name)
+	}
+	if version, ok := findAttribute(attrs, semconv.ServiceVersionKey); ok {
+		t.Errorf("service.version = %q, want it left to the environment", version)
+	}
+
+	// An explicit name in the config file wins over the environment.
+	attrs, err = otelResourceAttributes("from-config", nil, fromEnv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name, _ := findAttribute(attrs, semconv.ServiceNameKey); name != "from-config" {
+		t.Errorf("service.name = %q, want %q", name, "from-config")
+	}
+
+	// With neither set, sshmux falls back to its own default.
+	attrs, err = otelResourceAttributes("", nil, unnamed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name, _ := findAttribute(attrs, semconv.ServiceNameKey); name != defaultServiceName {
+		t.Errorf("service.name = %q, want %q", name, defaultServiceName)
+	}
+	if _, ok := findAttribute(attrs, semconv.ServiceVersionKey); !ok {
+		t.Error("service.version is missing, want the build version")
+	}
+
+	// Attributes from the config file are always applied.
+	attrs, err = otelResourceAttributes("", []ResourceAttributeConfig{{Name: "env", Value: "staging"}}, unnamed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value, _ := findAttribute(attrs, attribute.Key("env")); value != "staging" {
+		t.Errorf("env = %q, want %q", value, "staging")
+	}
+
+	if _, err := otelResourceAttributes("", []ResourceAttributeConfig{{Value: "no name"}}, unnamed); err == nil {
+		t.Error("a nameless resource attribute should be rejected")
+	}
+}
+
+// findAttribute reports the value carried for key, and whether it is there.
+func findAttribute(attrs []attribute.KeyValue, key attribute.Key) (string, bool) {
+	for _, attr := range attrs {
+		if attr.Key == key {
+			return attr.Value.AsString(), true
+		}
+	}
+	return "", false
+}
+
+// TestConventionAttributeNames pins how each convention resolves, and that the
+// two lines currently agree — the property that lets `ecs` be the stable choice
+// today at no cost.
+func TestConventionAttributeNames(t *testing.T) {
+	for _, convention := range []AttributeConvention{"", AttributeConventionDefault} {
+		names, err := conventionAttributeNames(convention)
+		if err != nil {
+			t.Fatalf("convention %q: %v", convention, err)
+		}
+		if names != defaultAttributeNames {
+			t.Errorf("convention %q did not resolve to the semantic conventions", convention)
+		}
+	}
+	names, err := conventionAttributeNames(AttributeConventionECS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if names != ecsAttributeNames {
+		t.Error(`convention "ecs" did not resolve to the Elastic Common Schema`)
+	}
+
+	// The conventions adopted these fields from ECS, so the two lines name
+	// every attribute identically. This will stop holding when they diverge,
+	// and the test is what will say so.
+	if defaultAttributeNames != ecsAttributeNames {
+		t.Log("the conventions have diverged; the README table needs updating")
+	}
+
+	if _, err := conventionAttributeNames("nonsense"); err == nil {
+		t.Error("an unknown convention should be refused")
+	}
+}

--- a/sshmux.go
+++ b/sshmux.go
@@ -516,7 +516,7 @@ func (s *Server) Start() error {
 	// set up TCP listener
 	listener, err := reuse.Listen("tcp", s.Address)
 	if err != nil {
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), metricsShutdownTimeout)
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), otelShutdownTimeout)
 		s.Metrics.Shutdown(shutdownCtx)
 		cancel()
 		return err
@@ -586,7 +586,7 @@ func (s *Server) Shutdown() {
 	}
 	s.wg.Wait()
 	// flush the final measurements once no handler can record anymore
-	ctx, cancel := context.WithTimeout(context.Background(), metricsShutdownTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), otelShutdownTimeout)
 	defer cancel()
 	s.Metrics.Shutdown(ctx)
 }

--- a/sshmux.go
+++ b/sshmux.go
@@ -169,11 +169,12 @@ func (s *Server) handler(conn net.Conn) {
 	defer conn.Close()
 
 	connectTime := time.Now()
-	s.Metrics.ConnectionAccepted(s.ctx)
+	ctx := s.ctx
+	s.Metrics.ConnectionAccepted(ctx)
 	var sessionErr error
 	var info connectionInfo
 	defer func() {
-		s.Metrics.ConnectionClosed(s.ctx, info, sessionErr, time.Since(connectTime))
+		s.Metrics.ConnectionClosed(ctx, info, sessionErr, time.Since(connectTime))
 	}()
 
 	if err := conn.SetDeadline(time.Now().Add(s.HandshakeTimeout)); err != nil {
@@ -201,7 +202,7 @@ func (s *Server) handler(conn net.Conn) {
 	case <-s.ctx.Done():
 		return
 	default:
-		attrs, err := s.RunPipeSession(session, &info)
+		attrs, err := s.RunPipeSession(ctx, session, &info)
 		if err != nil && err != io.EOF {
 			log.Println("runPipeSession:", err)
 		}
@@ -243,7 +244,7 @@ func answerChallenges(session *ssh.PipeSession, req *AuthRequest, challenges []A
 	return nil
 }
 
-func (s *Server) Handshake(session *ssh.PipeSession, info *connectionInfo) error {
+func (s *Server) Handshake(ctx context.Context, session *ssh.PipeSession, info *connectionInfo) error {
 	hasSetUser := false
 	var user string
 	var upstream *upstreamInformation
@@ -284,7 +285,7 @@ auth_requests:
 			req.PublicKey = string(ssh.MarshalAuthorizedKey(*authReq.PublicKey))
 		}
 		for {
-			status, resp, err := s.Authenticator.Auth(req, user)
+			status, resp, err := s.Authenticator.Auth(ctx, req, user)
 			if err != nil {
 				return err
 			}
@@ -489,9 +490,9 @@ auth_requests:
 	}
 }
 
-func (s *Server) RunPipeSession(session *ssh.PipeSession, info *connectionInfo) ([]slog.Attr, error) {
+func (s *Server) RunPipeSession(ctx context.Context, session *ssh.PipeSession, info *connectionInfo) ([]slog.Attr, error) {
 	handshakeTime := time.Now()
-	err := s.Handshake(session, info)
+	err := s.Handshake(ctx, session, info)
 	s.Metrics.HandshakeFinished(s.ctx, *info, err, time.Since(handshakeTime))
 	if err != nil {
 		return nil, err

--- a/sshmux.go
+++ b/sshmux.go
@@ -182,8 +182,6 @@ func (s *Server) handler(conn net.Conn) {
 	defer conn.Close()
 
 	connectTime := time.Now()
-	s.Metrics.ConnectionAccepted(s.ctx)
-	var sessionErr error
 	var info connectionInfo
 	if address, ok := conn.RemoteAddr().(*net.TCPAddr); ok {
 		info.ClientHost, info.ClientPort = address.IP.String(), uint16(address.Port)
@@ -194,20 +192,31 @@ func (s *Server) handler(conn net.Conn) {
 	if proxied, ok := conn.(*proxyproto.Conn); ok {
 		info.ClientPeer = proxied.Raw().RemoteAddr()
 	}
+
+	// The span covers establishing the session, not its lifetime: a session
+	// that is up lasts as long as the client stays connected, and a span left
+	// open that long is held in memory and reaches no exporter until it ends.
+	// How long a session lived is reported by `sshmux.session.duration`.
+	ctx, span := s.Tracer.Start(s.ctx, "establish ssh session", spanKindServer)
+	s.Metrics.ConnectionAccepted(ctx)
+	var sessionErr error
 	defer func() {
-		s.Metrics.ConnectionClosed(s.ctx, info, sessionErr, time.Since(connectTime))
+		s.Metrics.ConnectionClosed(ctx, info, sessionErr, time.Since(connectTime))
 	}()
 
-	if err := conn.SetDeadline(time.Now().Add(s.HandshakeTimeout)); err != nil {
-		sessionErr = err
-		return
-	}
-	session, err := ssh.NewPipeSession(conn, s.SSHConfig)
-	if err != nil {
+	session, attrs, err := s.establishSession(ctx, conn, &info)
+	endSpan(span, err, append(s.Tracer.connectionSpanAttributes(info),
+		s.Tracer.peerAttributes(info.ClientPeer)...)...)
+	// A connection that never reached the SSH transport has nothing to log
+	// about a session, and nothing to close.
+	if session == nil {
 		sessionErr = err
 		return
 	}
 	defer session.Close()
+	if err != nil && err != io.EOF {
+		log.Println("runPipeSession:", err)
+	}
 
 	logger := slog.New(slog.NewJSONHandler(s.LogWriter, nil))
 	logger = logger.With(
@@ -215,25 +224,26 @@ func (s *Server) handler(conn net.Conn) {
 		slog.String("remote_ip", conn.RemoteAddr().String()),
 		slog.String("client_type", "SSH"),
 	)
+	for _, attr := range attrs {
+		logger = logger.With(attr)
+	}
 	defer func() {
 		logger.Info("SSH proxy session", slog.Int64("disconnect_time", time.Now().Unix()))
 	}()
+
+	if err != nil {
+		// Once the session is up, the client ends it by disconnecting, so only
+		// a failure to establish one counts against the session result.
+		sessionErr = err
+		return
+	}
 
 	select {
 	case <-s.ctx.Done():
 		return
 	default:
-		attrs, err := s.RunPipeSession(s.ctx, session, &info)
-		if err != nil && err != io.EOF {
+		if err := session.RunPipe(); err != nil && err != io.EOF {
 			log.Println("runPipeSession:", err)
-		}
-		// Once the session is up, the client ends it by disconnecting, so only
-		// a failure to establish one counts against the session result.
-		if !info.Established {
-			sessionErr = err
-		}
-		for _, attr := range attrs {
-			logger = logger.With(attr)
 		}
 	}
 }
@@ -531,37 +541,32 @@ auth_requests:
 	}
 }
 
-func (s *Server) RunPipeSession(ctx context.Context, session *ssh.PipeSession, info *connectionInfo) ([]slog.Attr, error) {
-	// The span covers establishing the session, not its lifetime: a session
-	// that is up lasts as long as the client stays connected, and a span left
-	// open that long is held in memory and reaches no exporter until it ends.
-	// How long a session lived is reported by `sshmux.session.duration`.
-	ctx, span := s.Tracer.Start(ctx, "establish ssh session", spanKindServer)
-	attrs, err := s.establishSession(ctx, session, info)
-	endSpan(span, err, append(s.Tracer.connectionSpanAttributes(*info),
-		s.Tracer.peerAttributes(info.ClientPeer)...)...)
-	if err != nil {
-		return nil, err
+// establishSession brings a connection up to a session ready to be piped. The
+// session is reported as soon as the SSH transport is up, so that a handshake
+// that fails afterwards is still closed and logged, and the log attributes only
+// once the session is established.
+func (s *Server) establishSession(ctx context.Context, conn net.Conn, info *connectionInfo) (*ssh.PipeSession, []slog.Attr, error) {
+	if err := conn.SetDeadline(time.Now().Add(s.HandshakeTimeout)); err != nil {
+		return nil, nil, err
 	}
-	return attrs, session.RunPipe()
-}
+	session, err := ssh.NewPipeSession(conn, s.SSHConfig)
+	if err != nil {
+		return nil, nil, err
+	}
 
-// establishSession runs the downstream handshake and reports the log
-// attributes of a session that is up.
-func (s *Server) establishSession(ctx context.Context, session *ssh.PipeSession, info *connectionInfo) ([]slog.Attr, error) {
 	handshakeTime := time.Now()
 	handshakeCtx, handshakeSpan := s.Tracer.Start(ctx, "ssh handshake")
-	err := s.Handshake(handshakeCtx, session, info)
+	err = s.Handshake(handshakeCtx, session, info)
 	endSpan(handshakeSpan, err, s.Tracer.connectionSpanAttributes(*info)...)
 	s.Metrics.HandshakeFinished(ctx, *info, err, time.Since(handshakeTime))
 	if err != nil {
-		return nil, err
+		return session, nil, err
 	}
 	info.Established = true
 	if err := session.SetDeadline(time.Time{}); err != nil {
-		return nil, err
+		return session, nil, err
 	}
-	return []slog.Attr{
+	return session, []slog.Attr{
 		slog.String("username", session.Downstream.User()),
 		slog.String("host_ip", session.Upstream.RemoteAddr().String()),
 		slog.Bool("authenticated", true),

--- a/sshmux.go
+++ b/sshmux.go
@@ -35,6 +35,7 @@ type Server struct {
 	HandshakeTimeout time.Duration
 	UpstreamTimeout  time.Duration
 	Metrics          *Metrics
+	Tracer           *Tracer
 }
 
 const (
@@ -117,12 +118,16 @@ func makeServer(config Config) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
+	tracer, err := makeTracer(config.Tracer)
+	if err != nil {
+		return nil, err
+	}
 	var authenticator Authenticator
 	if config.Auth.Version == "" || config.Auth.Version == "legacy" {
-		legacyAuthenticator := makeLegacyAuthenticator(config.Auth, config.Recovery)
+		legacyAuthenticator := makeLegacyAuthenticator(config.Auth, config.Recovery, tracer)
 		authenticator = &legacyAuthenticator
 	} else {
-		authenticator, err = makeAuthenticator(config.Auth)
+		authenticator, err = makeAuthenticator(config.Auth, tracer)
 		if err != nil {
 			return nil, err
 		}
@@ -138,6 +143,7 @@ func makeServer(config Config) (*Server, error) {
 		HandshakeTimeout: timeoutFromSeconds(config.SSH.HandshakeTimeoutSeconds, defaultHandshakeTimeout),
 		UpstreamTimeout:  timeoutFromSeconds(config.SSH.UpstreamTimeoutSeconds, defaultUpstreamTimeout),
 		Metrics:          metrics,
+		Tracer:           tracer,
 	}
 	return sshmux, nil
 }
@@ -519,6 +525,7 @@ func (s *Server) Start() error {
 	if err != nil {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), otelShutdownTimeout)
 		s.Metrics.Shutdown(shutdownCtx)
+		s.Tracer.Shutdown(shutdownCtx)
 		cancel()
 		return err
 	}
@@ -590,4 +597,5 @@ func (s *Server) Shutdown() {
 	ctx, cancel := context.WithTimeout(context.Background(), otelShutdownTimeout)
 	defer cancel()
 	s.Metrics.Shutdown(ctx)
+	s.Tracer.Shutdown(ctx)
 }

--- a/sshmux.go
+++ b/sshmux.go
@@ -13,11 +13,13 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
 	reuse "github.com/libp2p/go-reuseport"
 	"github.com/pires/go-proxyproto"
+	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -122,6 +124,11 @@ func makeServer(config Config) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
+	// The auth API is named on the span of every call made to it.
+	authEndpoint, err := url.Parse(config.Auth.Endpoint)
+	if err != nil {
+		return nil, err
+	}
 	var authenticator Authenticator
 	if config.Auth.Version == "" || config.Auth.Version == "legacy" {
 		legacyAuthenticator := makeLegacyAuthenticator(config.Auth, config.Recovery, tracer)
@@ -132,7 +139,7 @@ func makeServer(config Config) (*Server, error) {
 			return nil, err
 		}
 	}
-	authenticator = &instrumentedAuthenticator{inner: authenticator, metrics: metrics}
+	authenticator = &instrumentedAuthenticator{inner: authenticator, metrics: metrics, tracer: tracer, server: authEndpoint}
 	sshmux := &Server{
 		Address:          config.Address,
 		Banner:           config.SSH.Banner,
@@ -175,12 +182,20 @@ func (s *Server) handler(conn net.Conn) {
 	defer conn.Close()
 
 	connectTime := time.Now()
-	ctx := s.ctx
-	s.Metrics.ConnectionAccepted(ctx)
+	s.Metrics.ConnectionAccepted(s.ctx)
 	var sessionErr error
 	var info connectionInfo
+	if address, ok := conn.RemoteAddr().(*net.TCPAddr); ok {
+		info.ClientHost, info.ClientPort = address.IP.String(), uint16(address.Port)
+	}
+	// RemoteAddr is what a PROXY protocol header claims, so the connection has
+	// to be asked for the address it was really made from.
+	info.ClientPeer = conn.RemoteAddr()
+	if proxied, ok := conn.(*proxyproto.Conn); ok {
+		info.ClientPeer = proxied.Raw().RemoteAddr()
+	}
 	defer func() {
-		s.Metrics.ConnectionClosed(ctx, info, sessionErr, time.Since(connectTime))
+		s.Metrics.ConnectionClosed(s.ctx, info, sessionErr, time.Since(connectTime))
 	}()
 
 	if err := conn.SetDeadline(time.Now().Add(s.HandshakeTimeout)); err != nil {
@@ -208,7 +223,7 @@ func (s *Server) handler(conn net.Conn) {
 	case <-s.ctx.Done():
 		return
 	default:
-		attrs, err := s.RunPipeSession(ctx, session, &info)
+		attrs, err := s.RunPipeSession(s.ctx, session, &info)
 		if err != nil && err != io.EOF {
 			log.Println("runPipeSession:", err)
 		}
@@ -221,6 +236,16 @@ func (s *Server) handler(conn net.Conn) {
 			logger = logger.With(attr)
 		}
 	}
+}
+
+// sshProtocolVersion reads the protocol version out of an SSH identification
+// string, which RFC 4253 shapes as "SSH-protoversion-softwareversion".
+func sshProtocolVersion(identification string) string {
+	fields := strings.SplitN(identification, "-", 3)
+	if len(fields) < 3 || fields[0] != "SSH" {
+		return ""
+	}
+	return fields[1]
 }
 
 // answerChallenges prompts the downstream user with the given challenges over
@@ -263,6 +288,7 @@ func (s *Server) Handshake(ctx context.Context, session *ssh.PipeSession, info *
 	// Basic information about the downstream client, constant for the connection
 	clientAddress := session.Downstream.RemoteAddr().String()
 	clientVersion := string(session.Downstream.ClientVersion())
+	info.ProtocolVersion = sshProtocolVersion(clientVersion)
 	sessionID := base64.StdEncoding.EncodeToString(session.Downstream.SessionID())
 	// Stage 1: Authenticate the user with API
 	// The public key accepted by the API server, carried over to the later auth
@@ -403,8 +429,17 @@ auth_requests:
 		}
 	}
 	// Stage 2: connect to upstream
+	_, dialSpan := s.Tracer.Start(ctx, "connect upstream", spanKindClient)
 	conn, err := net.DialTimeout("tcp", upstream.Address, s.UpstreamTimeout)
-	s.Metrics.UpstreamDialed(s.ctx, err)
+	dialAttrs := []attribute.KeyValue{
+		s.Tracer.attrs.serverAddress.String(info.UpstreamHost),
+		s.Tracer.attrs.serverPort.Int(int(info.UpstreamPort)),
+	}
+	if err == nil {
+		dialAttrs = append(dialAttrs, s.Tracer.peerAttributes(conn.RemoteAddr())...)
+	}
+	endSpan(dialSpan, err, dialAttrs...)
+	s.Metrics.UpstreamDialed(ctx, err)
 	if err != nil {
 		return err
 	}
@@ -497,9 +532,28 @@ auth_requests:
 }
 
 func (s *Server) RunPipeSession(ctx context.Context, session *ssh.PipeSession, info *connectionInfo) ([]slog.Attr, error) {
+	// The span covers establishing the session, not its lifetime: a session
+	// that is up lasts as long as the client stays connected, and a span left
+	// open that long is held in memory and reaches no exporter until it ends.
+	// How long a session lived is reported by `sshmux.session.duration`.
+	ctx, span := s.Tracer.Start(ctx, "establish ssh session", spanKindServer)
+	attrs, err := s.establishSession(ctx, session, info)
+	endSpan(span, err, append(s.Tracer.connectionSpanAttributes(*info),
+		s.Tracer.peerAttributes(info.ClientPeer)...)...)
+	if err != nil {
+		return nil, err
+	}
+	return attrs, session.RunPipe()
+}
+
+// establishSession runs the downstream handshake and reports the log
+// attributes of a session that is up.
+func (s *Server) establishSession(ctx context.Context, session *ssh.PipeSession, info *connectionInfo) ([]slog.Attr, error) {
 	handshakeTime := time.Now()
-	err := s.Handshake(ctx, session, info)
-	s.Metrics.HandshakeFinished(s.ctx, *info, err, time.Since(handshakeTime))
+	handshakeCtx, handshakeSpan := s.Tracer.Start(ctx, "ssh handshake")
+	err := s.Handshake(handshakeCtx, session, info)
+	endSpan(handshakeSpan, err, s.Tracer.connectionSpanAttributes(*info)...)
+	s.Metrics.HandshakeFinished(ctx, *info, err, time.Since(handshakeTime))
 	if err != nil {
 		return nil, err
 	}
@@ -507,12 +561,11 @@ func (s *Server) RunPipeSession(ctx context.Context, session *ssh.PipeSession, i
 	if err := session.SetDeadline(time.Time{}); err != nil {
 		return nil, err
 	}
-	attrs := []slog.Attr{
+	return []slog.Attr{
 		slog.String("username", session.Downstream.User()),
 		slog.String("host_ip", session.Upstream.RemoteAddr().String()),
 		slog.Bool("authenticated", true),
-	}
-	return attrs, session.RunPipe()
+	}, nil
 }
 
 func (s *Server) Start() error {

--- a/sshmux_test.go
+++ b/sshmux_test.go
@@ -324,7 +324,7 @@ func serveDownstreamProxy(listener net.Listener) {
 
 // startServer starts sshmux from a fixture and records the address it listens
 // on.
-func startServer(t *testing.T, configFile string) *Server {
+func startServer(t *testing.T, configFile string, adjust ...func(*Config)) *Server {
 	t.Helper()
 	config, err := loadConfig(filepath.Join("fixtures", configFile))
 	if err != nil {
@@ -340,6 +340,9 @@ func startServer(t *testing.T, configFile string) *Server {
 	}
 	endpoint.Host = apiServerAddr.String()
 	config.Auth.Endpoint = endpoint.String()
+	for _, adjust := range adjust {
+		adjust(&config)
+	}
 
 	sshmux, err := makeServer(config)
 	if err != nil {
@@ -685,5 +688,105 @@ func TestSSHPartialAuthChallengeClientConnection(t *testing.T) {
 	t.Run("proxied both ways", func(t *testing.T) {
 		requireProxySource(t)
 		testWithGolangSSHPartialAuthClient(t, sshmuxProxyAddr, true)
+	})
+}
+
+// startMetricsServer starts sshmux with the metrics fixture, adjusted to the
+// addresses this run actually uses and to the exporter these tests read from.
+func startMetricsServer(t *testing.T) *Server {
+	t.Helper()
+	return startServer(t, "metrics.toml", func(config *Config) {
+		// The fixture exercises the configuration surface, not these tests: it
+		// names an OTLP collector that is not listening, a fixed Prometheus
+		// port, and turns off the connection grouping the assertions read.
+		config.Metrics.OTLP.Enabled = false
+		config.Metrics.Prometheus.Address = "127.0.0.1:0"
+		config.Metrics.ConnectionGrouping = nil
+	})
+}
+
+// dropConnection connects to address and hangs up without saying anything.
+func dropConnection(t *testing.T, address *net.TCPAddr) {
+	t.Helper()
+	conn, err := net.Dial("tcp", address.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn.Close()
+}
+
+// scrapeUntil polls the Prometheus endpoint until want shows up, since a
+// session is only recorded once its handler winds down.
+func scrapeUntil(t *testing.T, metrics *Metrics, want string) string {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var body string
+	for time.Now().Before(deadline) {
+		body = scrape(t, metrics)
+		if strings.Contains(body, want) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return body
+}
+
+// testSessionMetrics checks that a connection that went away before the SSH
+// handshake is still accounted for as an accepted and then failed session.
+func testSessionMetrics(t *testing.T, metrics *Metrics) {
+	t.Helper()
+	body := scrapeUntil(t, metrics, "sshmux_sessions_total{")
+	for _, want := range []string{
+		`sshmux_connections_total 1`,
+		`sshmux_connections_active 0`,
+		`sshmux_sessions_total{`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("scrape output does not contain %q:\n%s", want, body)
+		}
+	}
+}
+
+// testUpstreamMetrics checks that the backend address the auth API returned
+// reaches the metrics.
+func testUpstreamMetrics(t *testing.T, metrics *Metrics) {
+	t.Helper()
+	currentUser, err := user.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := fmt.Sprintf(`sshmux_sessions_total{event_outcome="success",server_address=%q,server_port="%d",user_name=%q} 1`,
+		sshdServerAddr.IP.String(), sshdServerAddr.Port, currentUser.Username)
+	if body := scrapeUntil(t, metrics, want); !strings.Contains(body, want) {
+		t.Errorf("scrape output does not contain %q:\n%s", want, body)
+	}
+}
+
+// TestServerMetricsWiring checks that a connection served by the real server
+// shows up in the exported metrics, i.e. that the instruments are wired into
+// the connection handler and not just reachable in isolation.
+func TestServerMetricsWiring(t *testing.T) {
+	initEnv(t)
+
+	sshmux := startMetricsServer(t)
+	defer sshmux.Shutdown()
+
+	t.Run("dropped connection", func(t *testing.T) {
+		dropConnection(t, sshmuxServerAddr)
+		testSessionMetrics(t, sshmux.Metrics)
+	})
+}
+
+// TestServerMetricsUpstreamGrouping drives a real SSH client through sshmux and
+// checks that the backend address the auth API returned reaches the metrics.
+func TestServerMetricsUpstreamGrouping(t *testing.T) {
+	initEnv(t)
+
+	sshmux := startMetricsServer(t)
+	defer sshmux.Shutdown()
+
+	t.Run("sshmux", func(t *testing.T) {
+		testWithSSHClient(t, sshmuxServerAddr, false)
+		testUpstreamMetrics(t, sshmux.Metrics)
 	})
 }

--- a/sshmux_test.go
+++ b/sshmux_test.go
@@ -1,25 +1,33 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 	"log"
+	"maps"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"os/exec"
 	"os/user"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/pires/go-proxyproto"
+	collectortrace "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
 	"golang.org/x/crypto/ssh"
+	"google.golang.org/protobuf/proto"
 )
 
 // The addresses of the services making up the test environment. None of them
@@ -789,4 +797,223 @@ func TestServerMetricsUpstreamGrouping(t *testing.T) {
 		testWithSSHClient(t, sshmuxServerAddr, false)
 		testUpstreamMetrics(t, sshmux.Metrics)
 	})
+}
+
+func collectSpans(t *testing.T) (*httptest.Server, func() []*tracev1.Span) {
+	t.Helper()
+	var mu sync.Mutex
+	var spans []*tracev1.Span
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			return
+		}
+		var request collectortrace.ExportTraceServiceRequest
+		if err := proto.Unmarshal(body, &request); err != nil {
+			return
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		for _, resource := range request.ResourceSpans {
+			for _, scope := range resource.ScopeSpans {
+				spans = append(spans, scope.Spans...)
+			}
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server, func() []*tracev1.Span {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]*tracev1.Span(nil), spans...)
+	}
+}
+
+// flushSpans exports whatever the batcher is holding, so that the spans of a
+// finished session can be inspected without shutting the server down.
+func flushSpans(t *testing.T, sshmux *Server) {
+	t.Helper()
+	if err := sshmux.Tracer.ForceFlush(t.Context()); err != nil {
+		t.Fatal("flush spans: ", err)
+	}
+}
+
+// testWithHeldSSHClient brings a session up and runs check while the client is
+// still connected, so that what reached the collector mid-session can be told
+// apart from what only arrives once the session closes.
+func testWithHeldSSHClient(t *testing.T, address *net.TCPAddr, check func()) {
+	t.Helper()
+	enableProxy = false
+	cmd := onetimeSSHDServer(t)
+	defer stopSSHD(t, cmd)
+
+	key, err := os.ReadFile("fixtures/ssh_id_rsa")
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := ssh.ParsePrivateKey(key)
+	if err != nil {
+		t.Fatal("parse client key: ", err)
+	}
+	currentUser, err := user.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := ssh.Dial("tcp", address.String(), &ssh.ClientConfig{
+		User:            currentUser.Username,
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         5 * time.Second,
+	})
+	if err != nil {
+		t.Fatal("failed to dial: ", err)
+	}
+	defer client.Close()
+
+	check()
+}
+
+// awaitSpans flushes until want spans have been exported: the server finishes
+// the last of them just after the client sees the session come up.
+func awaitSpans(t *testing.T, sshmux *Server, spans func() []*tracev1.Span, want int) []*tracev1.Span {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var exported []*tracev1.Span
+	for time.Now().Before(deadline) {
+		flushSpans(t, sshmux)
+		if exported = spans(); len(exported) >= want {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return exported
+}
+
+// spanHasAttribute reports whether a span carries key.
+func spanHasAttribute(span *tracev1.Span, key string) bool {
+	for _, attr := range span.Attributes {
+		if attr.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
+// testSpanTree checks that a session produced the expected spans, and that
+// they nest under one another.
+func testSpanTree(t *testing.T, spans []*tracev1.Span) {
+	t.Helper()
+
+	byName := map[string]*tracev1.Span{}
+	for _, span := range spans {
+		byName[span.Name] = span
+	}
+	for _, want := range []string{"establish ssh session", "ssh handshake", "authenticate user", "connect upstream"} {
+		if _, ok := byName[want]; !ok {
+			t.Errorf("no %q span was exported; got %v", want, slices.Sorted(maps.Keys(byName)))
+		}
+	}
+	session, handshake := byName["establish ssh session"], byName["ssh handshake"]
+	if session == nil || handshake == nil {
+		t.Fatal("missing the spans needed to check nesting")
+	}
+	if len(session.ParentSpanId) != 0 {
+		t.Error(`"establish ssh session" has a parent, want it to be the trace root`)
+	}
+	if !bytes.Equal(handshake.ParentSpanId, session.SpanId) {
+		t.Error(`"ssh handshake" is not a child of "establish ssh session"`)
+	}
+	if auth := byName["authenticate user"]; auth != nil && !bytes.Equal(auth.ParentSpanId, handshake.SpanId) {
+		t.Error(`"authenticate user" is not a child of "ssh handshake"`)
+	}
+	// A collector builds its service graph out of the kinds, so the session
+	// sshmux serves and the calls it makes on that session's behalf have to be
+	// told apart.
+	if session.Kind != tracev1.Span_SPAN_KIND_SERVER {
+		t.Errorf("session span kind = %v, want SPAN_KIND_SERVER", session.Kind)
+	}
+	for _, name := range []string{"authenticate user", "connect upstream"} {
+		if span := byName[name]; span != nil && span.Kind != tracev1.Span_SPAN_KIND_CLIENT {
+			t.Errorf("%q span kind = %v, want SPAN_KIND_CLIENT", name, span.Kind)
+		}
+	}
+	// Which addresses a span names follows from its kind: the session is
+	// reached from a client, the auth and dial spans reach out to a server.
+	wantAttributes := map[string][]string{
+		"establish ssh session": {
+			"network.protocol.name", "network.protocol.version",
+			"user.name",
+			"client.address", "client.port",
+			"network.peer.address", "network.peer.port",
+		},
+		"authenticate user": {"server.address", "server.port", "network.peer.address", "network.peer.port"},
+		"connect upstream":  {"server.address", "server.port", "network.peer.address", "network.peer.port"},
+	}
+	for name, keys := range wantAttributes {
+		span := byName[name]
+		if span == nil {
+			continue
+		}
+		for _, key := range keys {
+			if !spanHasAttribute(span, key) {
+				t.Errorf("%q span carries no %q attribute", name, key)
+			}
+		}
+	}
+	if handshake := byName["ssh handshake"]; handshake != nil {
+		// An internal span covers no connection, so it has no peer to name.
+		for _, key := range []string{"network.peer.address", "network.peer.port"} {
+			if spanHasAttribute(handshake, key) {
+				t.Errorf(`"ssh handshake" carries %q, want no peer on an internal span`, key)
+			}
+		}
+	}
+	for name, span := range byName {
+		if !bytes.Equal(span.TraceId, session.TraceId) {
+			t.Errorf("%q is in a different trace from the session", name)
+		}
+	}
+}
+
+func TestServerSpans(t *testing.T) {
+	initEnv(t)
+
+	collector, spans := collectSpans(t)
+	sshmux := startServer(t, "tracer.toml", func(config *Config) {
+		// The fixture exercises the configuration surface, not this test: it
+		// names a gRPC collector, samples a quarter of traces, which would make
+		// the assertions intermittent, and asks for the ECS attribute names,
+		// which spell the application protocol differently.
+		config.Tracer.OTLP.Protocol = "http"
+		config.Tracer.OTLP.Endpoint = collector.URL + "/v1/traces"
+		config.Tracer.SampleRatio = nil
+		config.Tracer.Convention = AttributeConventionDefault
+	})
+	defer sshmux.Shutdown()
+
+	t.Run("sshmux", func(t *testing.T) {
+		testWithHeldSSHClient(t, sshmuxServerAddr, func() {
+			// Every span of the session has to be exported while the client is
+			// still connected: a span left open for the life of a session is
+			// held in memory and never reaches the collector.
+			testSpanTree(t, awaitSpans(t, sshmux, spans, 4))
+		})
+	})
+}
+
+func TestSSHProtocolVersion(t *testing.T) {
+	cases := []struct{ identification, want string }{
+		{"SSH-2.0-OpenSSH_9.9", "2.0"},
+		// The software version is free to carry more dashes, and comments.
+		{"SSH-2.0-Go-1.2 some comment", "2.0"},
+		{"SSH-1.99-OpenSSH_3.9", "1.99"},
+		{"SSH-2.0-", "2.0"},
+		{"", ""},
+		{"SSH-2.0", ""},
+		{"HTTP/1.1-nonsense-here", ""},
+	}
+	for _, tc := range cases {
+		if got := sshProtocolVersion(tc.identification); got != tc.want {
+			t.Errorf("sshProtocolVersion(%q) = %q, want %q", tc.identification, got, tc.want)
+		}
+	}
 }

--- a/sshmux_test.go
+++ b/sshmux_test.go
@@ -828,6 +828,22 @@ func collectSpans(t *testing.T) (*httptest.Server, func() []*tracev1.Span) {
 	}
 }
 
+// startTracerServer starts sshmux with the tracer fixture, pointed at a
+// collector these tests can read back.
+func startTracerServer(t *testing.T, collector *httptest.Server) *Server {
+	t.Helper()
+	return startServer(t, "tracer.toml", func(config *Config) {
+		// The fixture exercises the configuration surface, not these tests: it
+		// names a gRPC collector, samples a quarter of traces, which would make
+		// the assertions intermittent, and asks for the ECS attribute names,
+		// which spell the application protocol differently.
+		config.Tracer.OTLP.Protocol = "http"
+		config.Tracer.OTLP.Endpoint = collector.URL + "/v1/traces"
+		config.Tracer.SampleRatio = nil
+		config.Tracer.Convention = AttributeConventionDefault
+	})
+}
+
 // flushSpans exports whatever the batcher is holding, so that the spans of a
 // finished session can be inspected without shutting the server down.
 func flushSpans(t *testing.T, sshmux *Server) {
@@ -889,6 +905,15 @@ func awaitSpans(t *testing.T, sshmux *Server, spans func() []*tracev1.Span, want
 }
 
 // spanHasAttribute reports whether a span carries key.
+// spanNames reports the names of spans, for a failed assertion to show.
+func spanNames(spans []*tracev1.Span) []string {
+	names := make([]string, 0, len(spans))
+	for _, span := range spans {
+		names = append(names, span.Name)
+	}
+	return names
+}
+
 func spanHasAttribute(span *tracev1.Span, key string) bool {
 	for _, attr := range span.Attributes {
 		if attr.Key == key {
@@ -978,16 +1003,7 @@ func TestServerSpans(t *testing.T) {
 	initEnv(t)
 
 	collector, spans := collectSpans(t)
-	sshmux := startServer(t, "tracer.toml", func(config *Config) {
-		// The fixture exercises the configuration surface, not this test: it
-		// names a gRPC collector, samples a quarter of traces, which would make
-		// the assertions intermittent, and asks for the ECS attribute names,
-		// which spell the application protocol differently.
-		config.Tracer.OTLP.Protocol = "http"
-		config.Tracer.OTLP.Endpoint = collector.URL + "/v1/traces"
-		config.Tracer.SampleRatio = nil
-		config.Tracer.Convention = AttributeConventionDefault
-	})
+	sshmux := startTracerServer(t, collector)
 	defer sshmux.Shutdown()
 
 	t.Run("sshmux", func(t *testing.T) {
@@ -1016,4 +1032,43 @@ func TestSSHProtocolVersion(t *testing.T) {
 			t.Errorf("sshProtocolVersion(%q) = %q, want %q", tc.identification, got, tc.want)
 		}
 	}
+}
+
+// testFailedSessionSpan checks the span of a connection that never reached the
+// SSH transport: there is one, it is the session span, and it failed.
+func testFailedSessionSpan(t *testing.T, spans []*tracev1.Span) {
+	t.Helper()
+	if len(spans) != 1 {
+		t.Fatalf("%d spans were exported, want 1: %v", len(spans), spanNames(spans))
+	}
+	span := spans[0]
+	if span.Name != "establish ssh session" {
+		t.Errorf("the span is %q, want %q", span.Name, "establish ssh session")
+	}
+	if span.Kind != tracev1.Span_SPAN_KIND_SERVER {
+		t.Errorf("span kind = %v, want SPAN_KIND_SERVER", span.Kind)
+	}
+	if span.Status.GetCode() != tracev1.Status_STATUS_CODE_ERROR {
+		t.Errorf("span status = %v, want STATUS_CODE_ERROR", span.Status.GetCode())
+	}
+	for _, key := range []string{"client.address", "client.port", "network.peer.address"} {
+		if !spanHasAttribute(span, key) {
+			t.Errorf("the span carries no %q attribute", key)
+		}
+	}
+}
+
+// TestServerSpanWithoutSession checks that a connection dropped before the SSH
+// transport is up is still traced, rather than only counted.
+func TestServerSpanWithoutSession(t *testing.T) {
+	initEnv(t)
+
+	collector, spans := collectSpans(t)
+	sshmux := startTracerServer(t, collector)
+	defer sshmux.Shutdown()
+
+	t.Run("dropped connection", func(t *testing.T) {
+		dropConnection(t, sshmuxServerAddr)
+		testFailedSessionSpan(t, awaitSpans(t, sshmux, spans, 1))
+	})
 }

--- a/tracer.go
+++ b/tracer.go
@@ -5,8 +5,15 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
+	"net/http/httptrace"
+	"net/url"
+	"slices"
+	"strconv"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
@@ -113,6 +120,120 @@ func makeOTLPTraceExporter(config OTLPConfig) (*otlptrace.Exporter, error) {
 	return otlptracehttp.New(ctx, options...)
 }
 
+// Start begins a span. The returned context carries it, so that spans started
+// from it nest, and the trace context reaches the auth API. It is safe to call
+// while tracing is disabled, when the span is a no-op.
+func (t *Tracer) Start(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	return t.tracer.Start(ctx, name, opts...)
+}
+
+// The kinds of span sshmux records: what it serves to a client, and the calls
+// it makes to other services on that client's behalf.
+var (
+	spanKindServer = trace.WithSpanKind(trace.SpanKindServer)
+	spanKindClient = trace.WithSpanKind(trace.SpanKindClient)
+)
+
+// endSpan records the outcome of a span and ends it. Attributes are only built
+// for a span that is actually recording.
+func endSpan(span trace.Span, err error, attrs ...attribute.KeyValue) {
+	if span.IsRecording() {
+		setSpanAttributes(span, attrs)
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+	}
+	span.End()
+}
+
+// setSpanAttributes records attrs on span, dropping the ones a convention has
+// no name for and so left with an empty key. Every attribute sshmux records
+// reaches a span through here.
+func setSpanAttributes(span trace.Span, attrs []attribute.KeyValue) {
+	attrs = slices.DeleteFunc(attrs, func(attr attribute.KeyValue) bool { return attr.Key == "" })
+	if len(attrs) > 0 {
+		span.SetAttributes(attrs...)
+	}
+}
+
+// connectionSpanAttributes reports the parts of a connection's identity that
+// are known. Unlike the metrics, an unknown value is left off rather than
+// recorded as "unknown", since a span has no cardinality budget to protect.
+func (t *Tracer) connectionSpanAttributes(info connectionInfo) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{t.attrs.networkProtocolName.String("ssh")}
+	if info.ProtocolVersion != "" {
+		attrs = append(attrs, t.attrs.networkProtocolVersion.String(info.ProtocolVersion))
+	}
+	if info.Username != "" {
+		attrs = append(attrs, t.attrs.userName.String(info.Username))
+	}
+	if info.ClientHost != "" {
+		attrs = append(attrs, t.attrs.clientAddress.String(info.ClientHost),
+			t.attrs.clientPort.Int(int(info.ClientPort)))
+	}
+	if info.UpstreamHost != "" {
+		attrs = append(attrs, t.attrs.serverAddress.String(info.UpstreamHost),
+			t.attrs.serverPort.Int(int(info.UpstreamPort)))
+	}
+	return attrs
+}
+
+// serverAttributes names the service a client span called, taking the port a
+// URL leaves out from its scheme.
+func (t *Tracer) serverAttributes(server *url.URL) []attribute.KeyValue {
+	if server == nil || server.Hostname() == "" {
+		return nil
+	}
+	attrs := []attribute.KeyValue{t.attrs.serverAddress.String(server.Hostname())}
+	port := server.Port()
+	if port == "" {
+		port = portForScheme(server.Scheme)
+	}
+	if number, err := strconv.Atoi(port); err == nil {
+		attrs = append(attrs, t.attrs.serverPort.Int(number))
+	}
+	return attrs
+}
+
+func portForScheme(scheme string) string {
+	switch scheme {
+	case "http":
+		return "80"
+	case "https":
+		return "443"
+	}
+	return ""
+}
+
+// tracePeer arranges for the address an HTTP request ends up connected to be
+// recorded on the span already in ctx, which only the transport knows.
+func (t *Tracer) tracePeer(ctx context.Context) context.Context {
+	if !t.enabled {
+		return ctx
+	}
+	span := trace.SpanFromContext(ctx)
+	return httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
+		GotConn: func(info httptrace.GotConnInfo) {
+			setSpanAttributes(span, t.peerAttributes(info.Conn.RemoteAddr()))
+		},
+	})
+}
+
+// peerAttributes names the other end of the network connection a span covers:
+// where it was reached from for a server span, and what it reached out to for
+// a client span.
+func (t *Tracer) peerAttributes(peer net.Addr) []attribute.KeyValue {
+	tcp, ok := peer.(*net.TCPAddr)
+	if !ok {
+		return nil
+	}
+	return []attribute.KeyValue{
+		t.attrs.networkPeerAddress.String(tcp.IP.String()),
+		t.attrs.networkPeerPort.Int(tcp.Port),
+	}
+}
+
 // Inject writes the trace context of ctx into an outgoing request's headers,
 // so that the server handling it can continue the same trace. It does nothing
 // while tracing or propagation is off, or while ctx carries no span.
@@ -121,6 +242,15 @@ func (t *Tracer) Inject(ctx context.Context, header http.Header) {
 		return
 	}
 	t.propagator.Inject(ctx, propagation.HeaderCarrier(header))
+}
+
+// ForceFlush exports whatever the batcher is holding, without tearing the
+// provider down.
+func (t *Tracer) ForceFlush(ctx context.Context) error {
+	if !t.enabled || t.provider == nil {
+		return nil
+	}
+	return t.provider.ForceFlush(ctx)
 }
 
 // Shutdown flushes pending spans and tears down the exporter.

--- a/tracer.go
+++ b/tracer.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+// Tracer owns the OpenTelemetry tracer provider of an sshmux server and the
+// tracer that spans are started from. Its span methods are no-ops while
+// tracing is disabled.
+type Tracer struct {
+	enabled  bool
+	provider *sdktrace.TracerProvider
+	tracer   trace.Tracer
+	// attrs holds the attribute names the configured convention resolved to.
+	attrs attributeNames
+}
+
+func makeTracer(config TracerConfig) (*Tracer, error) {
+	names, err := conventionAttributeNames(config.Convention)
+	if err != nil {
+		return nil, err
+	}
+	if !config.Enabled {
+		return &Tracer{tracer: noop.NewTracerProvider().Tracer(otelScopeName), attrs: names}, nil
+	}
+	if !config.OTLP.Enabled {
+		return nil, errors.New("tracing is enabled but no exporter is configured")
+	}
+	if config.SampleRatio != nil && (*config.SampleRatio < 0 || *config.SampleRatio > 1) {
+		return nil, fmt.Errorf("tracer.sample-ratio must be between 0 and 1, got %v", *config.SampleRatio)
+	}
+
+	exporter, err := makeOTLPTraceExporter(config.OTLP)
+	if err != nil {
+		return nil, err
+	}
+	res, err := otelResource(config.ServiceName, config.Attributes)
+	if err != nil {
+		return nil, err
+	}
+	options := []sdktrace.TracerProviderOption{
+		sdktrace.WithResource(res),
+		sdktrace.WithBatcher(exporter),
+	}
+	// Leaving the ratio unset defers to OTEL_TRACES_SAMPLER, and in turn to the
+	// SDK default of sampling every trace whose parent is sampled.
+	if config.SampleRatio != nil {
+		options = append(options, sdktrace.WithSampler(
+			sdktrace.ParentBased(sdktrace.TraceIDRatioBased(*config.SampleRatio))))
+	}
+	provider := sdktrace.NewTracerProvider(options...)
+	return &Tracer{enabled: true, provider: provider, tracer: provider.Tracer(otelScopeName), attrs: names}, nil
+}
+
+func makeOTLPTraceExporter(config OTLPConfig) (*otlptrace.Exporter, error) {
+	protocol, err := otlpProtocol(config.Protocol, envOTLPTracesProtocol)
+	if err != nil {
+		return nil, err
+	}
+	endpoint, err := otlpEndpoint(config, protocol)
+	if err != nil {
+		return nil, err
+	}
+	headers := otlpHeaders(config)
+	ctx := context.Background()
+
+	if protocol == "grpc" {
+		var options []otlptracegrpc.Option
+		if endpoint != nil {
+			options = append(options, otlptracegrpc.WithEndpointURL(endpoint.String()))
+		}
+		if len(headers) > 0 {
+			options = append(options, otlptracegrpc.WithHeaders(headers))
+		}
+		if timeout, ok := otlpTimeout(config); ok {
+			options = append(options, otlptracegrpc.WithTimeout(timeout))
+		}
+		return otlptracegrpc.New(ctx, options...)
+	}
+
+	var options []otlptracehttp.Option
+	if endpoint != nil {
+		// A configured endpoint is a signal-specific one, so it is used as-is,
+		// the same way OTEL_EXPORTER_OTLP_TRACES_ENDPOINT is. Only the generic
+		// OTEL_EXPORTER_OTLP_ENDPOINT is a base URL that `/v1/traces` is
+		// appended to, which the exporter handles itself.
+		options = append(options, otlptracehttp.WithEndpointURL(endpoint.String()))
+	}
+	if len(headers) > 0 {
+		options = append(options, otlptracehttp.WithHeaders(headers))
+	}
+	if timeout, ok := otlpTimeout(config); ok {
+		options = append(options, otlptracehttp.WithTimeout(timeout))
+	}
+	return otlptracehttp.New(ctx, options...)
+}
+
+// Shutdown flushes pending spans and tears down the exporter.
+func (t *Tracer) Shutdown(ctx context.Context) {
+	if !t.enabled || t.provider == nil {
+		return
+	}
+	if err := t.provider.Shutdown(ctx); err != nil {
+		log.Printf("Error on tracer shutdown: %s\n", err)
+	}
+	t.provider = nil
+}

--- a/tracer.go
+++ b/tracer.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/propagation"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
@@ -23,6 +25,8 @@ type Tracer struct {
 	tracer   trace.Tracer
 	// attrs holds the attribute names the configured convention resolved to.
 	attrs attributeNames
+	// propagator is nil when trace context is not carried to the auth API.
+	propagator propagation.TextMapPropagator
 }
 
 func makeTracer(config TracerConfig) (*Tracer, error) {
@@ -59,7 +63,11 @@ func makeTracer(config TracerConfig) (*Tracer, error) {
 			sdktrace.ParentBased(sdktrace.TraceIDRatioBased(*config.SampleRatio))))
 	}
 	provider := sdktrace.NewTracerProvider(options...)
-	return &Tracer{enabled: true, provider: provider, tracer: provider.Tracer(otelScopeName), attrs: names}, nil
+	tracer := &Tracer{enabled: true, provider: provider, tracer: provider.Tracer(otelScopeName), attrs: names}
+	if boolOrDefault(config.Propagation, true) {
+		tracer.propagator = propagation.TraceContext{}
+	}
+	return tracer, nil
 }
 
 func makeOTLPTraceExporter(config OTLPConfig) (*otlptrace.Exporter, error) {
@@ -103,6 +111,16 @@ func makeOTLPTraceExporter(config OTLPConfig) (*otlptrace.Exporter, error) {
 		options = append(options, otlptracehttp.WithTimeout(timeout))
 	}
 	return otlptracehttp.New(ctx, options...)
+}
+
+// Inject writes the trace context of ctx into an outgoing request's headers,
+// so that the server handling it can continue the same trace. It does nothing
+// while tracing or propagation is off, or while ctx carries no span.
+func (t *Tracer) Inject(ctx context.Context, header http.Header) {
+	if t.propagator == nil {
+		return
+	}
+	t.propagator.Inject(ctx, propagation.HeaderCarrier(header))
 }
 
 // Shutdown flushes pending spans and tears down the exporter.

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestTracerDisabled(t *testing.T) {
+	tracer, err := makeTracer(TracerConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The tracer must stay usable, so that span call sites need no guard.
+	_, span := tracer.tracer.Start(context.Background(), "test")
+	span.End()
+	tracer.Shutdown(context.Background())
+}
+
+func TestTracerWithoutExporter(t *testing.T) {
+	if _, err := makeTracer(TracerConfig{Enabled: true}); err == nil {
+		t.Fatal("tracing without an exporter should fail to start")
+	}
+}
+
+func TestTracerSampleRatioRange(t *testing.T) {
+	for _, ratio := range []float64{-0.5, 1.5} {
+		config := TracerConfig{
+			Enabled:     true,
+			SampleRatio: &ratio,
+			OTLP:        OTLPConfig{Enabled: true, Endpoint: "http://127.0.0.1:4318/v1/traces"},
+		}
+		if _, err := makeTracer(config); err == nil {
+			t.Errorf("sample-ratio %v should be rejected", ratio)
+		}
+	}
+}
+
+// TestTracerOTLPExport drives a span all the way to an OTLP collector, so that
+// the exporter wiring and the shutdown flush are both covered.
+func TestTracerOTLPExport(t *testing.T) {
+	paths := make(chan string, 4)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case paths <- r.URL.Path:
+		default:
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tracer, err := makeTracer(TracerConfig{
+		Enabled: true,
+		OTLP:    OTLPConfig{Enabled: true, Endpoint: server.URL + "/v1/traces"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, span := tracer.tracer.Start(context.Background(), "sshmux.session")
+	span.End()
+
+	ctx, cancel := context.WithTimeout(context.Background(), otelShutdownTimeout)
+	defer cancel()
+	tracer.Shutdown(ctx)
+
+	select {
+	case path := <-paths:
+		if path != "/v1/traces" {
+			t.Fatalf("OTLP request path = %q, want %q", path, "/v1/traces")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("no OTLP export was received")
+	}
+}
+
+func TestMakeOTLPTraceExporterErrors(t *testing.T) {
+	cases := []struct {
+		name   string
+		config OTLPConfig
+	}{
+		{"bad scheme", OTLPConfig{Enabled: true, Endpoint: "udp://127.0.0.1:4318"}},
+		{"unknown protocol", OTLPConfig{Enabled: true, Endpoint: "http://127.0.0.1:4318", Protocol: "thrift"}},
+		{"grpc with path", OTLPConfig{Enabled: true, Endpoint: "http://127.0.0.1:4317/v1/traces", Protocol: "grpc"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := makeOTLPTraceExporter(tc.config); err == nil {
+				t.Fatal("makeOTLPTraceExporter() error = nil, want an error")
+			}
+		})
+	}
+}
+
+func TestMakeOTLPTraceExporterProtocols(t *testing.T) {
+	for _, protocol := range []string{"", "http", "http/protobuf", "grpc"} {
+		endpoint := "https://otel.example.com:4318/otlp"
+		if protocol == "grpc" {
+			endpoint = "https://otel.example.com:4317"
+		}
+		exporter, err := makeOTLPTraceExporter(OTLPConfig{Enabled: true, Protocol: protocol, Endpoint: endpoint})
+		if err != nil {
+			t.Fatalf("protocol %q: %v", protocol, err)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), otelShutdownTimeout)
+		exporter.Shutdown(ctx)
+		cancel()
+	}
+}
+
+func noopTracer() *Tracer {
+	tracer, err := makeTracer(TracerConfig{})
+	if err != nil {
+		panic(err)
+	}
+	return tracer
+}

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -115,4 +116,72 @@ func noopTracer() *Tracer {
 		panic(err)
 	}
 	return tracer
+}
+
+// TestTracerPropagation checks that a span's context reaches the auth API as a
+// W3C traceparent header, and that tracer.propagation turns it off.
+func TestTracerPropagation(t *testing.T) {
+	cases := []struct {
+		name        string
+		propagation *bool
+		enabled     bool
+		wantHeader  bool
+	}{
+		{name: "on by default", enabled: true, wantHeader: true},
+		{name: "explicitly off", enabled: true, propagation: new(bool)},
+		{name: "tracing disabled", enabled: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			headers := make(chan string, 4)
+			api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				select {
+				case headers <- r.Header.Get("Traceparent"):
+				default:
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(`{"upstream":{"host":"127.0.0.1","port":22}}`))
+			}))
+			defer api.Close()
+
+			collector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer collector.Close()
+
+			config := TracerConfig{Enabled: tc.enabled, Propagation: tc.propagation}
+			if tc.enabled {
+				config.OTLP = OTLPConfig{Enabled: true, Endpoint: collector.URL + "/v1/traces"}
+			}
+			tracer, err := makeTracer(config)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer tracer.Shutdown(t.Context())
+
+			authenticator, err := makeAuthenticator(AuthConfig{Endpoint: api.URL, Version: "v1"}, tracer)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// A span has to be active for there to be any context to carry.
+			ctx, span := tracer.tracer.Start(t.Context(), "sshmux.handshake")
+			_, _, err = authenticator.Auth(ctx, AuthRequest{Method: "publickey"}, "vlab")
+			span.End()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got := <-headers
+			if tc.wantHeader {
+				if !strings.HasPrefix(got, "00-") || len(got) != 55 {
+					t.Fatalf("traceparent = %q, want a W3C header", got)
+				}
+				if id := span.SpanContext().TraceID().String(); !strings.Contains(got, id) {
+					t.Errorf("traceparent %q does not carry trace ID %s", got, id)
+				}
+			} else if got != "" {
+				t.Fatalf("traceparent = %q, want none", got)
+			}
+		})
+	}
 }

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -2,11 +2,16 @@ package main
 
 import (
 	"context"
+	"maps"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 	"time"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 func TestTracerDisabled(t *testing.T) {
@@ -59,7 +64,7 @@ func TestTracerOTLPExport(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, span := tracer.tracer.Start(context.Background(), "sshmux.session")
+	_, span := tracer.tracer.Start(context.Background(), "establish ssh session")
 	span.End()
 
 	ctx, cancel := context.WithTimeout(context.Background(), otelShutdownTimeout)
@@ -110,6 +115,7 @@ func TestMakeOTLPTraceExporterProtocols(t *testing.T) {
 	}
 }
 
+// noopTracer is a disabled tracer, for tests that only need the argument.
 func noopTracer() *Tracer {
 	tracer, err := makeTracer(TracerConfig{})
 	if err != nil {
@@ -164,7 +170,7 @@ func TestTracerPropagation(t *testing.T) {
 				t.Fatal(err)
 			}
 			// A span has to be active for there to be any context to carry.
-			ctx, span := tracer.tracer.Start(t.Context(), "sshmux.handshake")
+			ctx, span := tracer.tracer.Start(t.Context(), "ssh handshake")
 			_, _, err = authenticator.Auth(ctx, AuthRequest{Method: "publickey"}, "vlab")
 			span.End()
 			if err != nil {
@@ -183,5 +189,50 @@ func TestTracerPropagation(t *testing.T) {
 				t.Fatalf("traceparent = %q, want none", got)
 			}
 		})
+	}
+}
+
+// TestSpanAttributesDropUnnamed covers the rule that a convention with no name
+// for an attribute leaves its key empty, and that nothing with an empty key
+// reaches a span.
+func TestSpanAttributesDropUnnamed(t *testing.T) {
+	tracer, err := makeTracer(TracerConfig{Convention: AttributeConventionECS})
+	if err != nil {
+		t.Fatal(err)
+	}
+	attrs := tracer.connectionSpanAttributes(connectionInfo{Username: "vlab", ProtocolVersion: "2.0"})
+	// ECS has no name for the protocol version, so its key is left empty.
+	unnamed := 0
+	for _, attr := range attrs {
+		if attr.Key == "" {
+			unnamed++
+		}
+	}
+	if unnamed != 1 {
+		t.Errorf("%d attributes have no key, want 1 for the protocol version", unnamed)
+	}
+
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	_, span := provider.Tracer("test").Start(context.Background(), "test")
+	setSpanAttributes(span, attrs)
+	span.End()
+
+	recorded := recorder.Ended()
+	if len(recorded) != 1 {
+		t.Fatalf("%d spans were recorded, want 1", len(recorded))
+	}
+	keys := map[string]bool{}
+	for _, attr := range recorded[0].Attributes() {
+		if attr.Key == "" {
+			t.Error("an attribute with no key reached the span")
+		}
+		keys[string(attr.Key)] = true
+	}
+	if !keys["network.protocol"] {
+		t.Errorf(`no "network.protocol" attribute; got %v`, slices.Sorted(maps.Keys(keys)))
+	}
+	if keys["network.protocol.version"] {
+		t.Error("ECS has no name for the protocol version, want it dropped")
 	}
 }


### PR DESCRIPTION
This PR adds tracing support based on the [OpenTelemetry](https://opentelemetry.io) SDK, configured under a new `tracer` config group:
- `tracer.otlp` pushes spans to a collector, over either the `http` or the `grpc` protocol;
- `tracer.sample-ratio` records a fraction of traces, recording every one by default;
- `tracer.propagation` sends W3C trace context on auth API requests, so an instrumented auth server continues the same trace;
- `tracer.convention`, `tracer.service-name` and `tracer.attributes` behave as their `metrics` counterparts do, including the fallback to the standard `OTEL_*` environment variables.

The spans are:

| Span | Kind | Parent | Attributes | Covers |
| --- | --- | --- | --- | --- |
| `establish ssh session` | `server` | — | Connection, peer | Accepting the connection through to a session that is up. |
| `ssh handshake` | `internal` | `establish ssh session` | Connection | The downstream handshake and authentication. |
| `authenticate user` | `client` | `ssh handshake` | `server.*`, peer, `sshmux.auth.method`, `sshmux.auth.status` | One request to the auth API. |
| `connect upstream` | `client` | `ssh handshake` | `server.*`, peer | Dialling the backend. |

They are named after OpenTelemetry's `{verb} {object}` guidance, not the dotted namespaces used for metrics, which the conventions scope to attribute, metric and event names. The session span covers establishing the session rather than its lifetime: a session lasts as long as the client stays connected, and a span left open that long is held in memory and never reaches an exporter, while how long one lived is already reported by `sshmux.session.duration`. It opens as the connection is accepted, so a connection lost before the SSH transport is up is traced rather than only counted.

The connection attributes are `network.protocol.name`, `network.protocol.version`, `user.name`, `client.address`, `client.port`, `server.address` and `server.port`. Those name the logical ends, the ones behind any intermediary; a span's peer is the address at the other end of the network connection the span itself covers, which its kind fixes, and which a PROXY protocol hop makes differ. The auth API request takes its peer from `net/http/httptrace`, since only the transport knows the connection it ended up on.

The protocol version comes off the SSH identification string, and is the first attribute the two conventions do not share: `ecs` spells the protocol `network.protocol`, and has no field at all for its version, so that one is dropped there.

Outside the `tracer` group, `Authenticator.Auth` takes a `context.Context` so that spans nest and trace context reaches the auth API; the resource, OTLP endpoint, protocol, header and timeout handling and the attribute conventions move to `otel.go` to be shared by both signals, renaming `makeOTLPExporter` to `makeOTLPMetricExporter`; `instrumentedAuthenticator` moves to `auth.go`; `RunPipeSession` folds into an `establishSession` the connection handler calls, leaving bringing a session up and piping it as separate steps; and the two metrics tests that run a real server move to `sshmux_test.go`, built from the helpers the other end-to-end tests use.

The traces exporters reuse the gRPC and protobuf code the metrics ones already link in, so the artifacts grow far less than in https://github.com/USTC-vlab/sshmux/pull/30:

| Artifact | `master` | This PR | Growth |
| --- | --- | --- | --- |
| Binary (`linux/amd64`) | 16.58 MiB | 17.15 MiB | +0.57 MiB |
| Docker image | 18.71 MiB | 19.28 MiB | +0.57 MiB |

---

**Disclaimer:** This PR is drafted in heavy cooperation with [Claude Code](https://claude.com/product/claude-code), tested and reviewed.