### PR TITLE
Adopt `session_id` and aligned `host_ip` to the legacy log shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,15 +117,17 @@ A shape names the document alone, so `shape = "ecs"` under the default `conventi
 
 `sshmux` wrote a shape of its own before it followed a schema, which `logger.udp.shape` still writes as `legacy`. It is a different document rather than a different spelling of one: the values change along with the names, and two attributes are joined into each address.
 
-| Attribute                         | `legacy`                                                    |
-| --------------------------------- | ----------------------------------------------------------- |
-| `session.id`                      | `session_id`                                                |
-| `client.address`, `client.port`   | `remote_ip`, as `host:port`                                 |
-| `sshmux.upstream.address`, `sshmux.upstream.port` | `host_ip`, as `host:port`                   |
-| `user.name`                       | `username`                                                  |
-| `network.protocol.name`           | `client_type`, always `SSH`                                 |
-| `sshmux.handshake.start`, `event.end` | `connect_time`, `disconnect_time`, as Unix seconds      |
-| `event.outcome`, `error.type`      | `authenticated`, and absent where establishing returned an error |
+| Attribute                             | `legacy`                                                    |
+| ------------------------------------- | ----------------------------------------------------------- |
+| `session.id`                          | `session_id`                                                |
+| `client.address`, `client.port`       | `remote_ip`, as `host:port`                                 |
+| `server.address`, `server.port`       | `host_ip`, as `host:port`                                   |
+| `user.name`                           | `username`                                                  |
+| `network.protocol.name`               | `client_type`, always `SSH`                                 |
+| `sshmux.handshake.start`, `event.end` | `connect_time`, `disconnect_time`, as Unix seconds          |
+| `event.outcome`, `error.type`         | `authenticated`, and absent where establishing returned an error |
+
+Both of its addresses are the logical ends: `remote_ip` is the client the [PROXY protocol](#proxy-protocol-settings) header claims, and `host_ip` the backend the auth API named. Where a hop sits on either side, the address the connection really ends at is `sshmux.downstream.*` or `sshmux.upstream.*`, which this shape has no name for.
 
 This shape is frozen. It gains no field beyond the table above, whatever else a record comes to carry, so that the consumers written against it keep reading exactly what they always have. A field it has no name for is left out, and a record that is not a session is written without the shape at all.
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ A shape names the document alone, so `shape = "ecs"` under the default `conventi
 
 | Attribute                         | `legacy`                                                    |
 | --------------------------------- | ----------------------------------------------------------- |
+| `session.id`                      | `session_id`                                                |
 | `client.address`, `client.port`   | `remote_ip`, as `host:port`                                 |
 | `sshmux.upstream.address`, `sshmux.upstream.port` | `host_ip`, as `host:port`                   |
 | `user.name`                       | `username`                                                  |

--- a/logger.go
+++ b/logger.go
@@ -568,8 +568,7 @@ func readSessionFields(record slog.Record, names attributeNames) sessionFields {
 	record.Attrs(func(attr slog.Attr) bool {
 		switch attr.Key {
 		case string(names.clientAddress), string(names.clientPort),
-			string(names.sshmuxUpstreamAddress), string(names.sshmuxUpstreamPort),
-			string(names.sessionID),
+			string(names.serverAddress), string(names.serverPort), string(names.sessionID),
 			string(names.userName), string(names.eventOutcome), string(names.errorType),
 			string(names.sshmuxHandshakeStart), string(names.eventEnd):
 			fields[attr.Key] = attr.Value
@@ -638,9 +637,9 @@ func (f sessionFields) legacyAttributes(names attributeNames) []slog.Attr {
 	if user, ok := f[string(names.userName)]; ok {
 		attrs = append(attrs, slog.String("username", user.String()))
 	}
-	// host_ip has always been the address the upstream connection ends at, not
-	// the one the auth API named.
-	if host, ok := f.hostPort(string(names.sshmuxUpstreamAddress), string(names.sshmuxUpstreamPort)); ok {
+	// The backend the auth API named, as `remote_ip` is the client the PROXY
+	// protocol header claims: both ends of the shape are the logical ones.
+	if host, ok := f.hostPort(string(names.serverAddress), string(names.serverPort)); ok {
 		attrs = append(attrs, slog.String("host_ip", host))
 	}
 	return append(attrs, slog.Bool("authenticated", true))

--- a/logger.go
+++ b/logger.go
@@ -569,6 +569,7 @@ func readSessionFields(record slog.Record, names attributeNames) sessionFields {
 		switch attr.Key {
 		case string(names.clientAddress), string(names.clientPort),
 			string(names.sshmuxUpstreamAddress), string(names.sshmuxUpstreamPort),
+			string(names.sessionID),
 			string(names.userName), string(names.eventOutcome), string(names.errorType),
 			string(names.sshmuxHandshakeStart), string(names.eventEnd):
 			fields[attr.Key] = attr.Value
@@ -612,6 +613,9 @@ func (f sessionFields) legacyAttributes(names attributeNames) []slog.Attr {
 		return nil
 	}
 	var attrs []slog.Attr
+	if session, ok := f[string(names.sessionID)]; ok {
+		attrs = append(attrs, slog.String("session_id", session.String()))
+	}
 	if connect, ok := f.unixTime(string(names.sshmuxHandshakeStart)); ok {
 		attrs = append(attrs, slog.Int64("connect_time", connect))
 	}

--- a/logger_test.go
+++ b/logger_test.go
@@ -558,9 +558,10 @@ func TestLogRecordLegacyShape(t *testing.T) {
 		"remote_ip":   "192.0.2.10:54321",
 		"client_type": "SSH",
 		"username":    "vlab",
-		// host_ip is the address the upstream connection ends at, which a
-		// PROXY protocol hop makes different from the backend the API named.
-		"host_ip":       "192.0.2.200:2222",
+		// host_ip is the backend the auth API named, as remote_ip is the client
+		// the header claims: both ends of this shape are the logical ones, and
+		// the hop the connection really ends at is 192.0.2.200:2222.
+		"host_ip":       "10.0.0.7:22",
 		"authenticated": true,
 		// The session an auth request can be joined to a record by.
 		"session_id": "c3NobXV4LXRlc3Qtc2Vzc2lvbg==",
@@ -681,6 +682,9 @@ func TestLegacyShapeIgnoresTheSockets(t *testing.T) {
 	}
 	if record["remote_ip"] != "192.0.2.10:54321" {
 		t.Errorf("remote_ip = %v, want the client the header claims", record["remote_ip"])
+	}
+	if record["host_ip"] != "10.0.0.7:22" {
+		t.Errorf("host_ip = %v, want the backend the auth API named", record["host_ip"])
 	}
 }
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -562,6 +562,8 @@ func TestLogRecordLegacyShape(t *testing.T) {
 		// PROXY protocol hop makes different from the backend the API named.
 		"host_ip":       "192.0.2.200:2222",
 		"authenticated": true,
+		// The session an auth request can be joined to a record by.
+		"session_id": "c3NobXV4LXRlc3Qtc2Vzc2lvbg==",
 	}
 	for key, value := range want {
 		if record[key] != value {
@@ -569,7 +571,7 @@ func TestLogRecordLegacyShape(t *testing.T) {
 		}
 	}
 	// The schema's names must be gone, not merely supplemented.
-	for _, key := range []string{"client.address", "server.address", "user.name", "event.outcome", "event.start"} {
+	for _, key := range []string{"client.address", "server.address", "user.name", "event.outcome", "event.start", "session.id"} {
 		if _, ok := record[key]; ok {
 			t.Errorf("%s is still present in the legacy shape", key)
 		}


### PR DESCRIPTION
A follow-up to https://github.com/USTC-vlab/sshmux/pull/37, which kept both of these out of an already large review rather than mixing a change to what the datagrams carry into it.

`session_id` is new. `sshmux` tells the auth API which session each request belongs to and told the records nothing, so a collector holding both had no way to put them together. The shape now carries the same identifier, under the name the API knows it by.

**`host_ip` changes value.** It has been the address the upstream connection really ends at — the [PROXY protocol](https://github.com/USTC-vlab/sshmux#proxy-protocol-settings) hop where one is configured, and resolved either way — while `remote_ip` beside it is the client that protocol's header claims: one socket and one logical end, in a pair that reads as two of a kind. It is now built from the backend the auth API named, so both are the logical ends. A collector reading it as the address actually dialled will see the backend instead; the addresses a connection really ends at are `sshmux.downstream.*` and `sshmux.upstream.*`, which the `ecs` and `otel` shapes carry.

With `session_id` in, the shape is proposed to be frozen. What a record gains from here stays out of it, and a consumer wanting more should read an `ecs` document.

---

**Disclaimer:** This PR is drafted by [Claude Code](https://claude.com/product/claude-code), tested and reviewed.